### PR TITLE
KOGITO-3630: Create "EditExpressionMenu" component

### DIFF
--- a/kie-wb-common-react/boxed-expression-editor/.eslintrc
+++ b/kie-wb-common-react/boxed-expression-editor/.eslintrc
@@ -14,7 +14,8 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
   ],
   "globals": {
     "window": "readonly",
@@ -34,7 +35,8 @@
   "plugins": [
     "@typescript-eslint",
     "react-hooks",
-    "eslint-plugin-react-hooks"
+    "eslint-plugin-react-hooks",
+    "prettier"
   ],
   "rules": {
     "@typescript-eslint/explicit-function-return-type": "off",
@@ -42,7 +44,7 @@
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "@typescript-eslint/interface-name-prefix": "off",
-    "prettier/prettier": "off",
+    "prettier/prettier": "error",
     "import/no-unresolved": "off",
     "import/extensions": "off",
     "react/prop-types": "off"

--- a/kie-wb-common-react/boxed-expression-editor/.gitignore
+++ b/kie-wb-common-react/boxed-expression-editor/.gitignore
@@ -5,6 +5,5 @@ yarn-error.log
 stats.json
 .DS_Store
 .idea
-**/__snapshots__/
 /coverage/
 react-app-env.d.ts

--- a/kie-wb-common-react/boxed-expression-editor/package.json
+++ b/kie-wb-common-react/boxed-expression-editor/package.json
@@ -5,7 +5,7 @@
     "prebuild": "rimraf dist",
     "build": "webpack --config webpack.prod.js",
     "test": "jest",
-    "lint": "eslint --ext .tsx,.js ./src/",
+    "lint": "eslint --ext .ts,.tsx,.js ./src/",
     "type-check": "tsc --noEmit",
     "quality-checks": "npm run type-check && npm run lint && npm run test"
   },

--- a/kie-wb-common-react/boxed-expression-editor/package.json
+++ b/kie-wb-common-react/boxed-expression-editor/package.json
@@ -24,6 +24,8 @@
     "css-loader": "^5.0.0",
     "dotenv-webpack": "^4.0.0",
     "eslint": "6.1.0",
+    "eslint-config-prettier": "^6.15.0",
+    "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.21.4",
     "eslint-plugin-react-hooks": "^4.1.2",
     "file-loader": "^6.1.1",

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/BoxedExpressionEditor.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/BoxedExpressionEditor.test.tsx
@@ -15,14 +15,14 @@
  */
 
 import * as React from "react";
-import {render} from "@testing-library/react";
-import {BoxedExpressionEditor} from "../../../components/BoxedExpressionEditor";
-import {ExpressionContainerProps} from "../../../components/ExpressionContainer";
+import { render } from "@testing-library/react";
+import { BoxedExpressionEditor } from "../../../components/BoxedExpressionEditor";
+import { ExpressionContainerProps } from "../../../components/ExpressionContainer";
 
-describe('BoxedExpressionEditor tests', () => {
-  test('should render BoxedExpressionEditor component', () => {
-    const expressionDefinition: ExpressionContainerProps = {'name': 'Expression Name'};
-    const { container } = render(<BoxedExpressionEditor expressionDefinition={expressionDefinition}/>);
+describe("BoxedExpressionEditor tests", () => {
+  test("should render BoxedExpressionEditor component", () => {
+    const expressionDefinition: ExpressionContainerProps = { name: "Expression Name" };
+    const { container } = render(<BoxedExpressionEditor expressionDefinition={expressionDefinition} />);
     expect(container).toMatchSnapshot();
   });
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/__snapshots__/BoxedExpressionEditor.test.tsx.snap
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/__snapshots__/BoxedExpressionEditor.test.tsx.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BoxedExpressionEditor tests should render BoxedExpressionEditor component 1`] = `
+<div>
+  <div
+    class="expression-container"
+  >
+    <span
+      id="expression-title"
+    >
+      Expression Name
+    </span>
+    <span
+      id="expression-type"
+    >
+      (
+      &lt;Undefined&gt;
+      )
+    </span>
+    <span
+      id="expression-actions"
+    >
+      <div
+        class="pf-c-dropdown"
+        data-ouia-component-id="OUIA-Generated-Dropdown-1"
+        data-ouia-component-type="PF4/Dropdown"
+        data-ouia-safe="true"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="Actions"
+          class="pf-c-dropdown__toggle pf-m-plain"
+          id="expression-actions-toggle"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 192 512"
+            width="1em"
+          >
+            <path
+              d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+            />
+          </svg>
+        </button>
+      </div>
+    </span>
+    <div
+      class="logic-type-not-present"
+      id="expression-container-box"
+    >
+      Select expression
+    </div>
+  </div>
+</div>
+`;

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/EditExpressionMenu/EditExpressionMenu.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/EditExpressionMenu/EditExpressionMenu.test.tsx
@@ -14,174 +14,210 @@
  * limitations under the License.
  */
 
-import {render} from "@testing-library/react";
-import {usingTestingBoxedExpressionI18nContext} from "../test-utils";
+import { render } from "@testing-library/react";
+import { usingTestingBoxedExpressionI18nContext } from "../test-utils";
 import * as React from "react";
-import {EditExpressionMenu} from "../../../components/EditExpressionMenu";
-import {activatePopover} from "../PopoverMenu/PopoverMenu.test";
-import {DataType, ExpressionProps} from "../../../api";
+import { EditExpressionMenu } from "../../../components/EditExpressionMenu";
+import { activatePopover } from "../PopoverMenu/PopoverMenu.test";
+import { DataType, ExpressionProps } from "../../../api";
 import * as _ from "lodash";
 
 jest.useFakeTimers();
 
-describe('EditExpressionMenu tests', () => {
-  test('should render Edit Expression title', async () => {
+describe("EditExpressionMenu tests", () => {
+  test("should render Edit Expression title", async () => {
     const title = "Edit Expression";
-    const {container} = render(usingTestingBoxedExpressionI18nContext(
-      <div>
-        <div id="container">Popover</div>
-        <EditExpressionMenu title={title}
-                            arrowPlacement={() => document.getElementById("container")!}
-                            appendTo={() => document.getElementById("container")!}
-                            onExpressionUpdate={(expression) => {console.log(expression)}}/>
-      </div>
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <div>
+          <div id="container">Popover</div>
+          <EditExpressionMenu
+            title={title}
+            arrowPlacement={() => document.getElementById("container")!}
+            appendTo={() => document.getElementById("container")!}
+            onExpressionUpdate={(expression) => {
+              console.log(expression);
+            }}
+          />
+        </div>
       ).wrapper
     );
 
     await activatePopover(container);
 
-    expect(container.querySelector(".selector-menu-title")).toBeTruthy()
+    expect(container.querySelector(".selector-menu-title")).toBeTruthy();
     expect(container.querySelector(".selector-menu-title")!.innerHTML).toBe(title);
   });
 
-  test('should render custom name field label', async () => {
+  test("should render custom name field label", async () => {
     const nameFieldLabel = "custom name field label";
-    const {container} = render(usingTestingBoxedExpressionI18nContext(
-      <div>
-        <div id="container">Popover</div>
-        <EditExpressionMenu nameField={nameFieldLabel}
-                            arrowPlacement={() => document.getElementById("container")!}
-                            appendTo={() => document.getElementById("container")!}
-                            onExpressionUpdate={(expression) => {console.log(expression)}}/>
-      </div>
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <div>
+          <div id="container">Popover</div>
+          <EditExpressionMenu
+            nameField={nameFieldLabel}
+            arrowPlacement={() => document.getElementById("container")!}
+            appendTo={() => document.getElementById("container")!}
+            onExpressionUpdate={(expression) => {
+              console.log(expression);
+            }}
+          />
+        </div>
       ).wrapper
     );
 
     await activatePopover(container);
 
-    expect(container.querySelector(".expression-name label")).toBeTruthy()
+    expect(container.querySelector(".expression-name label")).toBeTruthy();
     expect(container.querySelector(".expression-name label")!.innerHTML).toBe(nameFieldLabel);
   });
 
-  test('should render custom data type field label', async () => {
+  test("should render custom data type field label", async () => {
     const dataTypeFieldLabel = "custom data type field label";
-    const {container} = render(usingTestingBoxedExpressionI18nContext(
-      <div>
-        <div id="container">Popover</div>
-        <EditExpressionMenu dataTypeField={dataTypeFieldLabel}
-                            arrowPlacement={() => document.getElementById("container")!}
-                            appendTo={() => document.getElementById("container")!}
-                            onExpressionUpdate={(expression) => {console.log(expression)}}/>
-      </div>
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <div>
+          <div id="container">Popover</div>
+          <EditExpressionMenu
+            dataTypeField={dataTypeFieldLabel}
+            arrowPlacement={() => document.getElementById("container")!}
+            appendTo={() => document.getElementById("container")!}
+            onExpressionUpdate={(expression) => {
+              console.log(expression);
+            }}
+          />
+        </div>
       ).wrapper
     );
 
     await activatePopover(container);
 
-    expect(container.querySelector(".expression-data-type label")).toBeTruthy()
+    expect(container.querySelector(".expression-data-type label")).toBeTruthy();
     expect(container.querySelector(".expression-data-type label")!.innerHTML).toBe(dataTypeFieldLabel);
   });
 
-  test('should render undefined as data type, when it is not pre-selected', async () => {
-    const {container} = render(usingTestingBoxedExpressionI18nContext(
-      <div>
-        <div id="container">Popover</div>
-        <EditExpressionMenu arrowPlacement={() => document.getElementById("container")!}
-                            appendTo={() => document.getElementById("container")!}
-                            onExpressionUpdate={(expression) => {console.log(expression)}}/>
-      </div>
+  test("should render undefined as data type, when it is not pre-selected", async () => {
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <div>
+          <div id="container">Popover</div>
+          <EditExpressionMenu
+            arrowPlacement={() => document.getElementById("container")!}
+            appendTo={() => document.getElementById("container")!}
+            onExpressionUpdate={(expression) => {
+              console.log(expression);
+            }}
+          />
+        </div>
       ).wrapper
     );
 
     await activatePopover(container);
 
-    expect(container.querySelector("[id^='pf-select-toggle-id-']")).toBeTruthy()
-    expect((container.querySelector("[id^='pf-select-toggle-id-']")! as HTMLInputElement).value)
-      .toBe("<Undefined>");
+    expect(container.querySelector("[id^='pf-select-toggle-id-']")).toBeTruthy();
+    expect((container.querySelector("[id^='pf-select-toggle-id-']")! as HTMLInputElement).value).toBe("<Undefined>");
   });
 
-  test('should render passed data type, when it is pre-selected', async () => {
+  test("should render passed data type, when it is pre-selected", async () => {
     const selectedDataType = DataType.Date;
-    const {container} = render(usingTestingBoxedExpressionI18nContext(
-      <div>
-        <div id="container">Popover</div>
-        <EditExpressionMenu selectedDataType={selectedDataType}
-                            arrowPlacement={() => document.getElementById("container")!}
-                            appendTo={() => document.getElementById("container")!}
-                            onExpressionUpdate={(expression) => {console.log(expression)}}/>
-      </div>
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <div>
+          <div id="container">Popover</div>
+          <EditExpressionMenu
+            selectedDataType={selectedDataType}
+            arrowPlacement={() => document.getElementById("container")!}
+            appendTo={() => document.getElementById("container")!}
+            onExpressionUpdate={(expression) => {
+              console.log(expression);
+            }}
+          />
+        </div>
       ).wrapper
     );
 
     await activatePopover(container);
 
-    expect(container.querySelector("[id^='pf-select-toggle-id-']")).toBeTruthy()
-    expect((container.querySelector("[id^='pf-select-toggle-id-']")! as HTMLInputElement).value)
-      .toBe(selectedDataType);
+    expect(container.querySelector("[id^='pf-select-toggle-id-']")).toBeTruthy();
+    expect((container.querySelector("[id^='pf-select-toggle-id-']")! as HTMLInputElement).value).toBe(selectedDataType);
   });
 
-  test('should render empty expression name, when it is not pre-selected', async () => {
-    const {container} = render(usingTestingBoxedExpressionI18nContext(
-      <div>
-        <div id="container">Popover</div>
-        <EditExpressionMenu arrowPlacement={() => document.getElementById("container")!}
-                            appendTo={() => document.getElementById("container")!}
-                            onExpressionUpdate={(expression) => {console.log(expression)}}/>
-      </div>
+  test("should render empty expression name, when it is not pre-selected", async () => {
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <div>
+          <div id="container">Popover</div>
+          <EditExpressionMenu
+            arrowPlacement={() => document.getElementById("container")!}
+            appendTo={() => document.getElementById("container")!}
+            onExpressionUpdate={(expression) => {
+              console.log(expression);
+            }}
+          />
+        </div>
       ).wrapper
     );
 
     await activatePopover(container);
 
-    expect(container.querySelector("#expression-name")).toBeTruthy()
-    expect((container.querySelector("#expression-name")! as HTMLInputElement).value)
-      .toBe('');
+    expect(container.querySelector("#expression-name")).toBeTruthy();
+    expect((container.querySelector("#expression-name")! as HTMLInputElement).value).toBe("");
   });
 
-  test('should render passed expression name, when it is pre-selected', async () => {
+  test("should render passed expression name, when it is pre-selected", async () => {
     const expressionName = "a name";
-    const {container} = render(usingTestingBoxedExpressionI18nContext(
-      <div>
-        <div id="container">Popover</div>
-        <EditExpressionMenu selectedExpressionName={expressionName}
-                            arrowPlacement={() => document.getElementById("container")!}
-                            appendTo={() => document.getElementById("container")!}
-                            onExpressionUpdate={(expression) => {console.log(expression)}}/>
-      </div>
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <div>
+          <div id="container">Popover</div>
+          <EditExpressionMenu
+            selectedExpressionName={expressionName}
+            arrowPlacement={() => document.getElementById("container")!}
+            appendTo={() => document.getElementById("container")!}
+            onExpressionUpdate={(expression) => {
+              console.log(expression);
+            }}
+          />
+        </div>
       ).wrapper
     );
 
     await activatePopover(container);
 
-    expect(container.querySelector("#expression-name")).toBeTruthy()
-    expect((container.querySelector("#expression-name")! as HTMLInputElement).value)
-      .toBe(expressionName);
+    expect(container.querySelector("#expression-name")).toBeTruthy();
+    expect((container.querySelector("#expression-name")! as HTMLInputElement).value).toBe(expressionName);
   });
 
-  test('should trigger the onExpressionUpdate callback when the expression name is changed', async () => {
-    const onExpressionUpdate = (expression: ExpressionProps) => {_.identity(expression)};
+  test("should trigger the onExpressionUpdate callback when the expression name is changed", async () => {
+    const onExpressionUpdate = (expression: ExpressionProps) => {
+      _.identity(expression);
+    };
     const mockedOnExpressionUpdate = jest.fn(onExpressionUpdate);
-    const {container} = render(usingTestingBoxedExpressionI18nContext(
-      <div>
-        <div id="container">Popover</div>
-        <EditExpressionMenu selectedExpressionName="init"
-                            arrowPlacement={() => document.getElementById("container")!}
-                            appendTo={() => document.getElementById("container")!}
-                            onExpressionUpdate={mockedOnExpressionUpdate}/>
-      </div>
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <div>
+          <div id="container">Popover</div>
+          <EditExpressionMenu
+            selectedExpressionName="init"
+            arrowPlacement={() => document.getElementById("container")!}
+            appendTo={() => document.getElementById("container")!}
+            onExpressionUpdate={mockedOnExpressionUpdate}
+          />
+        </div>
       ).wrapper
     );
 
     await activatePopover(container);
 
     (container.querySelector("#expression-name") as HTMLInputElement)!.value = "changed";
-    (container.querySelector("#expression-name") as HTMLInputElement)!.dispatchEvent(new Event('change'));
-    (container.querySelector("#expression-name") as HTMLInputElement)!.dispatchEvent(new Event('blur'));
+    (container.querySelector("#expression-name") as HTMLInputElement)!.dispatchEvent(new Event("change"));
+    (container.querySelector("#expression-name") as HTMLInputElement)!.dispatchEvent(new Event("blur"));
 
     expect(mockedOnExpressionUpdate).toHaveBeenCalled();
     expect(mockedOnExpressionUpdate).toHaveBeenCalledWith({
       expressionName: "changed",
-      dataType: DataType.Undefined
+      dataType: DataType.Undefined,
     });
   });
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/EditExpressionMenu/EditExpressionMenu.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/EditExpressionMenu/EditExpressionMenu.test.tsx
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {render} from "@testing-library/react";
+import {usingTestingBoxedExpressionI18nContext} from "../test-utils";
+import * as React from "react";
+import {EditExpressionMenu} from "../../../components/EditExpressionMenu";
+import {activatePopover} from "../PopoverMenu/PopoverMenu.test";
+import {DataType, ExpressionProps} from "../../../api";
+import * as _ from "lodash";
+
+jest.useFakeTimers();
+
+describe('EditExpressionMenu tests', () => {
+  test('should render Edit Expression title', async () => {
+    const title = "Edit Expression";
+    const {container} = render(usingTestingBoxedExpressionI18nContext(
+      <div>
+        <div id="container">Popover</div>
+        <EditExpressionMenu title={title}
+                            arrowPlacement={() => document.getElementById("container")!}
+                            appendTo={() => document.getElementById("container")!}
+                            onExpressionUpdate={(expression) => {console.log(expression)}}/>
+      </div>
+      ).wrapper
+    );
+
+    await activatePopover(container);
+
+    expect(container.querySelector(".selector-menu-title")).toBeTruthy()
+    expect(container.querySelector(".selector-menu-title")!.innerHTML).toBe(title);
+  });
+
+  test('should render custom name field label', async () => {
+    const nameFieldLabel = "custom name field label";
+    const {container} = render(usingTestingBoxedExpressionI18nContext(
+      <div>
+        <div id="container">Popover</div>
+        <EditExpressionMenu nameField={nameFieldLabel}
+                            arrowPlacement={() => document.getElementById("container")!}
+                            appendTo={() => document.getElementById("container")!}
+                            onExpressionUpdate={(expression) => {console.log(expression)}}/>
+      </div>
+      ).wrapper
+    );
+
+    await activatePopover(container);
+
+    expect(container.querySelector(".expression-name label")).toBeTruthy()
+    expect(container.querySelector(".expression-name label")!.innerHTML).toBe(nameFieldLabel);
+  });
+
+  test('should render custom data type field label', async () => {
+    const dataTypeFieldLabel = "custom data type field label";
+    const {container} = render(usingTestingBoxedExpressionI18nContext(
+      <div>
+        <div id="container">Popover</div>
+        <EditExpressionMenu dataTypeField={dataTypeFieldLabel}
+                            arrowPlacement={() => document.getElementById("container")!}
+                            appendTo={() => document.getElementById("container")!}
+                            onExpressionUpdate={(expression) => {console.log(expression)}}/>
+      </div>
+      ).wrapper
+    );
+
+    await activatePopover(container);
+
+    expect(container.querySelector(".expression-data-type label")).toBeTruthy()
+    expect(container.querySelector(".expression-data-type label")!.innerHTML).toBe(dataTypeFieldLabel);
+  });
+
+  test('should render undefined as data type, when it is not pre-selected', async () => {
+    const {container} = render(usingTestingBoxedExpressionI18nContext(
+      <div>
+        <div id="container">Popover</div>
+        <EditExpressionMenu arrowPlacement={() => document.getElementById("container")!}
+                            appendTo={() => document.getElementById("container")!}
+                            onExpressionUpdate={(expression) => {console.log(expression)}}/>
+      </div>
+      ).wrapper
+    );
+
+    await activatePopover(container);
+
+    expect(container.querySelector("[id^='pf-select-toggle-id-']")).toBeTruthy()
+    expect((container.querySelector("[id^='pf-select-toggle-id-']")! as HTMLInputElement).value)
+      .toBe("<Undefined>");
+  });
+
+  test('should render passed data type, when it is pre-selected', async () => {
+    const selectedDataType = DataType.Date;
+    const {container} = render(usingTestingBoxedExpressionI18nContext(
+      <div>
+        <div id="container">Popover</div>
+        <EditExpressionMenu selectedDataType={selectedDataType}
+                            arrowPlacement={() => document.getElementById("container")!}
+                            appendTo={() => document.getElementById("container")!}
+                            onExpressionUpdate={(expression) => {console.log(expression)}}/>
+      </div>
+      ).wrapper
+    );
+
+    await activatePopover(container);
+
+    expect(container.querySelector("[id^='pf-select-toggle-id-']")).toBeTruthy()
+    expect((container.querySelector("[id^='pf-select-toggle-id-']")! as HTMLInputElement).value)
+      .toBe(selectedDataType);
+  });
+
+  test('should render empty expression name, when it is not pre-selected', async () => {
+    const {container} = render(usingTestingBoxedExpressionI18nContext(
+      <div>
+        <div id="container">Popover</div>
+        <EditExpressionMenu arrowPlacement={() => document.getElementById("container")!}
+                            appendTo={() => document.getElementById("container")!}
+                            onExpressionUpdate={(expression) => {console.log(expression)}}/>
+      </div>
+      ).wrapper
+    );
+
+    await activatePopover(container);
+
+    expect(container.querySelector("#expression-name")).toBeTruthy()
+    expect((container.querySelector("#expression-name")! as HTMLInputElement).value)
+      .toBe('');
+  });
+
+  test('should render passed expression name, when it is pre-selected', async () => {
+    const expressionName = "a name";
+    const {container} = render(usingTestingBoxedExpressionI18nContext(
+      <div>
+        <div id="container">Popover</div>
+        <EditExpressionMenu selectedExpressionName={expressionName}
+                            arrowPlacement={() => document.getElementById("container")!}
+                            appendTo={() => document.getElementById("container")!}
+                            onExpressionUpdate={(expression) => {console.log(expression)}}/>
+      </div>
+      ).wrapper
+    );
+
+    await activatePopover(container);
+
+    expect(container.querySelector("#expression-name")).toBeTruthy()
+    expect((container.querySelector("#expression-name")! as HTMLInputElement).value)
+      .toBe(expressionName);
+  });
+
+  test('should trigger the onExpressionUpdate callback when the expression name is changed', async () => {
+    const onExpressionUpdate = (expression: ExpressionProps) => {_.identity(expression)};
+    const mockedOnExpressionUpdate = jest.fn(onExpressionUpdate);
+    const {container} = render(usingTestingBoxedExpressionI18nContext(
+      <div>
+        <div id="container">Popover</div>
+        <EditExpressionMenu selectedExpressionName="init"
+                            arrowPlacement={() => document.getElementById("container")!}
+                            appendTo={() => document.getElementById("container")!}
+                            onExpressionUpdate={mockedOnExpressionUpdate}/>
+      </div>
+      ).wrapper
+    );
+
+    await activatePopover(container);
+
+    (container.querySelector("#expression-name") as HTMLInputElement)!.value = "changed";
+    (container.querySelector("#expression-name") as HTMLInputElement)!.dispatchEvent(new Event('change'));
+    (container.querySelector("#expression-name") as HTMLInputElement)!.dispatchEvent(new Event('blur'));
+
+    expect(mockedOnExpressionUpdate).toHaveBeenCalled();
+    expect(mockedOnExpressionUpdate).toHaveBeenCalledWith({
+      expressionName: "changed",
+      dataType: DataType.Undefined
+    });
+  });
+});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/EditExpressionMenu/__snapshots__/EditExpressionMenu.test.tsx.snap
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/EditExpressionMenu/__snapshots__/EditExpressionMenu.test.tsx.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PopoverMenu tests should render PopoverMenu component 1`] = `
+<div>
+  <div>
+    <div
+      id="container"
+    >
+      Popover
+      <div
+        aria-describedby="popover-menu-selector-body"
+        aria-labelledby="popover-menu-selector-header"
+        aria-modal="true"
+        class="pf-c-popover popover-menu-selector pf-m-bottom"
+        data-popper-placement="bottom"
+        role="dialog"
+        style="opacity: 1; transition: opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11); position: absolute; left: 0px; top: 0px; z-index: 9999; transform: translate(0px, 0px);"
+      >
+        <div
+          class="pf-c-popover__arrow"
+        />
+        <div
+          class="pf-c-popover__content"
+        >
+          <button
+            aria-disabled="false"
+            aria-label="Close"
+            class="pf-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Button-plain-1"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            style="pointer-events: auto;"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align: -0.125em;"
+              viewBox="0 0 352 512"
+              width="1em"
+            >
+              <path
+                d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+              />
+            </svg>
+          </button>
+          <h6
+            class="pf-c-title pf-m-md"
+            id="popover-menu-selector-header"
+          >
+            <div
+              class="selector-menu-title"
+            >
+              title
+            </div>
+          </h6>
+          <div
+            class="pf-c-popover__body"
+            id="popover-menu-selector-body"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/ExpressionContainer.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/ExpressionContainer.test.tsx
@@ -14,78 +14,92 @@
  * limitations under the License.
  */
 
-import {ExpressionContainer} from "../../../components/ExpressionContainer";
-import {render} from "@testing-library/react";
+import { ExpressionContainer } from "../../../components/ExpressionContainer";
+import { render } from "@testing-library/react";
 import * as React from "react";
-import {usingTestingBoxedExpressionI18nContext} from "../test-utils";
+import { usingTestingBoxedExpressionI18nContext } from "../test-utils";
 
-describe('ExpressionContainer tests', () => {
-  test('should render ExpressionContainer component', () => {
-    const {container} = render(usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test"/>).wrapper);
+describe("ExpressionContainer tests", () => {
+  test("should render ExpressionContainer component", () => {
+    const { container } = render(usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test" />).wrapper);
 
     expect(container).toMatchSnapshot();
   });
 
-  test('should render expression title, when name prop is passed', () => {
+  test("should render expression title, when name prop is passed", () => {
     const expressionTitle = "Test";
-    const {container} = render(usingTestingBoxedExpressionI18nContext(<ExpressionContainer
-      name={expressionTitle}/>).wrapper);
-    expect(container.querySelector("#expression-title")).toBeTruthy()
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(<ExpressionContainer name={expressionTitle} />).wrapper
+    );
+    expect(container.querySelector("#expression-title")).toBeTruthy();
     expect(container.querySelector("#expression-title")!.innerHTML).toBe(expressionTitle);
   });
 
-  test('should render expression type, when type prop is passed', () => {
+  test("should render expression type, when type prop is passed", () => {
     const type = "TYPE";
-    const {container} = render(usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test"
-                                                                                           type={type}/>).wrapper);
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test" type={type} />).wrapper
+    );
 
-    expect(container.querySelector("#expression-type")).toBeTruthy()
-    expect(container.querySelector("#expression-type")!.innerHTML).toBe('(' + type + ')');
+    expect(container.querySelector("#expression-type")).toBeTruthy();
+    expect(container.querySelector("#expression-type")!.innerHTML).toBe("(" + type + ")");
   });
 
-  test('should render expression type as undefined, when type prop is not passed', () => {
-    const {container} = render(usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test"/>).wrapper);
-    expect(container.querySelector("#expression-type")).toBeTruthy()
-    expect(container.querySelector("#expression-type")!.innerHTML).toBe('(&lt;Undefined&gt;)');
+  test("should render expression type as undefined, when type prop is not passed", () => {
+    const { container } = render(usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test" />).wrapper);
+    expect(container.querySelector("#expression-type")).toBeTruthy();
+    expect(container.querySelector("#expression-type")!.innerHTML).toBe("(&lt;Undefined&gt;)");
   });
 
-  describe('Expression Actions dropdown', () => {
-    test('should have the clear action disabled on startup', () => {
-      const {container} = render(usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test"/>).wrapper);
+  describe("Expression Actions dropdown", () => {
+    test("should have the clear action disabled on startup", () => {
+      const { container } = render(usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test" />).wrapper);
 
       const actionsToggleElement = container.querySelector("#expression-actions-toggle")!;
       const actionsToggleButton = actionsToggleElement as HTMLButtonElement;
       actionsToggleButton.click();
 
-      expect(container.querySelector(".pf-m-disabled.pf-c-dropdown__menu-item")).toBeTruthy()
-      expect(container.querySelector(".pf-m-disabled.pf-c-dropdown__menu-item")!.innerHTML).toBe('Clear');
+      expect(container.querySelector(".pf-m-disabled.pf-c-dropdown__menu-item")).toBeTruthy();
+      expect(container.querySelector(".pf-m-disabled.pf-c-dropdown__menu-item")!.innerHTML).toBe("Clear");
     });
 
-    test('should have the clear action enabled, when logic type is selected', () => {
-      const {container} = render(usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test" selectedExpression="Literal expression"/>).wrapper);
+    test("should have the clear action enabled, when logic type is selected", () => {
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <ExpressionContainer name="Test" selectedExpression="Literal expression" />
+        ).wrapper
+      );
 
       const actionsToggleElement = container.querySelector("#expression-actions-toggle")!;
       const actionsToggleButton = actionsToggleElement as HTMLButtonElement;
       actionsToggleButton.click();
 
-      expect(container.querySelector(".pf-m-disabled.pf-c-dropdown__menu-item")).toBeFalsy()
-      expect(container.querySelector(".pf-c-dropdown__menu-item")).toBeTruthy()
-      expect(container.querySelector(".pf-c-dropdown__menu-item")!.innerHTML).toBe('Clear');
+      expect(container.querySelector(".pf-m-disabled.pf-c-dropdown__menu-item")).toBeFalsy();
+      expect(container.querySelector(".pf-c-dropdown__menu-item")).toBeTruthy();
+      expect(container.querySelector(".pf-c-dropdown__menu-item")!.innerHTML).toBe("Clear");
     });
   });
 
-  describe('Logic type selection', () => {
-    test('should show the pre-selection, when logic type prop is passed', () => {
+  describe("Logic type selection", () => {
+    test("should show the pre-selection, when logic type prop is passed", () => {
       const expressionBoxContent = "Literal expression";
-      const {container} = render(usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test" selectedExpression={expressionBoxContent}/>).wrapper);
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <ExpressionContainer name="Test" selectedExpression={expressionBoxContent} />
+        ).wrapper
+      );
 
       expect(container.querySelector("#expression-container-box")).toBeTruthy();
       expect(container.querySelector("#expression-container-box")!.innerHTML).toBe(expressionBoxContent);
     });
 
-    test('should reset the selection, when logic type is selected and clear button gets clicked', () => {
+    test("should reset the selection, when logic type is selected and clear button gets clicked", () => {
       const expressionBoxContent = "Literal expression";
-      const {container} = render(usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test" selectedExpression={expressionBoxContent}/>).wrapper);
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <ExpressionContainer name="Test" selectedExpression={expressionBoxContent} />
+        ).wrapper
+      );
 
       const actionsToggleElement = container.querySelector("#expression-actions-toggle")!;
       const actionsToggleButton = actionsToggleElement as HTMLButtonElement;
@@ -99,5 +113,4 @@ describe('ExpressionContainer tests', () => {
       expect(container.querySelector("#expression-container-box")!.innerHTML).not.toBe(expressionBoxContent);
     });
   });
-
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/__snapshots__/ExpressionContainer.test.tsx.snap
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/__snapshots__/ExpressionContainer.test.tsx.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExpressionContainer tests should render ExpressionContainer component 1`] = `
+<div>
+  <div
+    class="expression-container"
+  >
+    <span
+      id="expression-title"
+    >
+      Test
+    </span>
+    <span
+      id="expression-type"
+    >
+      (
+      &lt;Undefined&gt;
+      )
+    </span>
+    <span
+      id="expression-actions"
+    >
+      <div
+        class="pf-c-dropdown"
+        data-ouia-component-id="OUIA-Generated-Dropdown-1"
+        data-ouia-component-type="PF4/Dropdown"
+        data-ouia-safe="true"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="Actions"
+          class="pf-c-dropdown__toggle pf-m-plain"
+          id="expression-actions-toggle"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 192 512"
+            width="1em"
+          >
+            <path
+              d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+            />
+          </svg>
+        </button>
+      </div>
+    </span>
+    <div
+      class="logic-type-not-present"
+      id="expression-container-box"
+    >
+      Select expression
+    </div>
+  </div>
+</div>
+`;

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/PopoverMenu/PopoverMenu.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/PopoverMenu/PopoverMenu.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {render} from "@testing-library/react";
+import {usingTestingBoxedExpressionI18nContext} from "../test-utils";
+import * as React from "react";
+import {PopoverMenu} from "../../../components/PopoverMenu";
+import {act} from "react-dom/test-utils";
+
+jest.useFakeTimers();
+const flushPromises = () => new Promise((resolve) => process.nextTick(resolve));
+
+describe('PopoverMenu tests', () => {
+  test('should render PopoverMenu component', async () => {
+    const {container} = render(usingTestingBoxedExpressionI18nContext(
+      <div>
+        <div id="container">Popover</div>
+        <PopoverMenu arrowPlacement={() => document.getElementById("container")!}
+                     body={null}
+                     title="title"/>
+      </div>
+     ).wrapper
+    );
+
+    await activatePopover(container);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  test('should render popover menu title, when title props is passed', async () => {
+    const title = "title";
+    const {container} = render(usingTestingBoxedExpressionI18nContext(
+      <div>
+        <div id="container">Popover</div>
+        <PopoverMenu arrowPlacement={() => document.getElementById("container")!}
+                     body={null}
+                     title={title}/>
+      </div>
+     ).wrapper
+    );
+
+    await activatePopover(container);
+
+    expect(container.querySelector(".selector-menu-title")).toBeTruthy()
+    expect(container.querySelector(".selector-menu-title")!.innerHTML).toBe(title);
+  });
+
+});
+
+async function activatePopover(container: HTMLElement) {
+  await act(async () => {
+    const popoverContainer = container.querySelector("#container")! as HTMLElement;
+    popoverContainer.click();
+    await flushPromises();
+    jest.runAllTimers();
+  });
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/PopoverMenu/PopoverMenu.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/PopoverMenu/PopoverMenu.test.tsx
@@ -62,7 +62,7 @@ describe('PopoverMenu tests', () => {
 
 });
 
-async function activatePopover(container: HTMLElement) {
+export async function activatePopover(container: HTMLElement): Promise<void> {
   await act(async () => {
     const popoverContainer = container.querySelector("#container")! as HTMLElement;
     popoverContainer.click();

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/PopoverMenu/PopoverMenu.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/PopoverMenu/PopoverMenu.test.tsx
@@ -14,26 +14,29 @@
  * limitations under the License.
  */
 
-import {render} from "@testing-library/react";
-import {usingTestingBoxedExpressionI18nContext} from "../test-utils";
+import { render } from "@testing-library/react";
+import { usingTestingBoxedExpressionI18nContext } from "../test-utils";
 import * as React from "react";
-import {PopoverMenu} from "../../../components/PopoverMenu";
-import {act} from "react-dom/test-utils";
+import { PopoverMenu } from "../../../components/PopoverMenu";
+import { act } from "react-dom/test-utils";
 
 jest.useFakeTimers();
 const flushPromises = () => new Promise((resolve) => process.nextTick(resolve));
 
-describe('PopoverMenu tests', () => {
-  test('should render PopoverMenu component', async () => {
-    const {container} = render(usingTestingBoxedExpressionI18nContext(
-      <div>
-        <div id="container">Popover</div>
-        <PopoverMenu arrowPlacement={() => document.getElementById("container")!}
-                     appendTo={() => document.getElementById("container")!}
-                     body={null}
-                     title="title"/>
-      </div>
-     ).wrapper
+describe("PopoverMenu tests", () => {
+  test("should render PopoverMenu component", async () => {
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <div>
+          <div id="container">Popover</div>
+          <PopoverMenu
+            arrowPlacement={() => document.getElementById("container")!}
+            appendTo={() => document.getElementById("container")!}
+            body={null}
+            title="title"
+          />
+        </div>
+      ).wrapper
     );
 
     await activatePopover(container);
@@ -41,25 +44,27 @@ describe('PopoverMenu tests', () => {
     expect(container).toMatchSnapshot();
   });
 
-  test('should render popover menu title, when title props is passed', async () => {
+  test("should render popover menu title, when title props is passed", async () => {
     const title = "title";
-    const {container} = render(usingTestingBoxedExpressionI18nContext(
-      <div>
-        <div id="container">Popover</div>
-        <PopoverMenu arrowPlacement={() => document.getElementById("container")!}
-                     appendTo={() => document.getElementById("container")!}
-                     body={null}
-                     title={title}/>
-      </div>
-     ).wrapper
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <div>
+          <div id="container">Popover</div>
+          <PopoverMenu
+            arrowPlacement={() => document.getElementById("container")!}
+            appendTo={() => document.getElementById("container")!}
+            body={null}
+            title={title}
+          />
+        </div>
+      ).wrapper
     );
 
     await activatePopover(container);
 
-    expect(container.querySelector(".selector-menu-title")).toBeTruthy()
+    expect(container.querySelector(".selector-menu-title")).toBeTruthy();
     expect(container.querySelector(".selector-menu-title")!.innerHTML).toBe(title);
   });
-
 });
 
 export async function activatePopover(container: HTMLElement): Promise<void> {

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/PopoverMenu/PopoverMenu.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/PopoverMenu/PopoverMenu.test.tsx
@@ -29,6 +29,7 @@ describe('PopoverMenu tests', () => {
       <div>
         <div id="container">Popover</div>
         <PopoverMenu arrowPlacement={() => document.getElementById("container")!}
+                     appendTo={() => document.getElementById("container")!}
                      body={null}
                      title="title"/>
       </div>
@@ -46,6 +47,7 @@ describe('PopoverMenu tests', () => {
       <div>
         <div id="container">Popover</div>
         <PopoverMenu arrowPlacement={() => document.getElementById("container")!}
+                     appendTo={() => document.getElementById("container")!}
                      body={null}
                      title={title}/>
       </div>

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/PopoverMenu/__snapshots__/PopoverMenu.test.tsx.snap
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/PopoverMenu/__snapshots__/PopoverMenu.test.tsx.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PopoverMenu tests should render PopoverMenu component 1`] = `
+<div>
+  <div>
+    <div
+      id="container"
+    >
+      Popover
+      <div
+        aria-describedby="popover-menu-selector-body"
+        aria-labelledby="popover-menu-selector-header"
+        aria-modal="true"
+        class="pf-c-popover popover-menu-selector pf-m-bottom"
+        data-popper-placement="bottom"
+        role="dialog"
+        style="opacity: 1; transition: opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11); position: absolute; left: 0px; top: 0px; z-index: 9999; transform: translate(0px, 0px);"
+      >
+        <div
+          class="pf-c-popover__arrow"
+        />
+        <div
+          class="pf-c-popover__content"
+        >
+          <button
+            aria-disabled="false"
+            aria-label="Close"
+            class="pf-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Button-plain-1"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            style="pointer-events: auto;"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align: -0.125em;"
+              viewBox="0 0 352 512"
+              width="1em"
+            >
+              <path
+                d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+              />
+            </svg>
+          </button>
+          <h6
+            class="pf-c-title pf-m-md"
+            id="popover-menu-selector-header"
+          >
+            <div
+              class="selector-menu-title"
+            >
+              title
+            </div>
+          </h6>
+          <div
+            class="pf-c-popover__body"
+            id="popover-menu-selector-body"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/test-utils.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/test-utils.tsx
@@ -15,15 +15,12 @@
  */
 
 import * as React from "react";
-import {
-  I18nDictionariesProvider,
-  I18nDictionariesProviderProps
-} from "@kogito-tooling/i18n/dist/react-components";
+import { I18nDictionariesProvider, I18nDictionariesProviderProps } from "@kogito-tooling/i18n/dist/react-components";
 import {
   boxedExpressionEditorDictionaries,
   BoxedExpressionEditorI18n,
   BoxedExpressionEditorI18nContext,
-  boxedExpressionEditorI18nDefaults
+  boxedExpressionEditorI18nDefaults,
 } from "../../i18n";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -36,7 +33,7 @@ export function usingTestingBoxedExpressionI18nContext(
     dictionaries: boxedExpressionEditorDictionaries,
     ctx: BoxedExpressionEditorI18nContext,
     children,
-    ...ctx
+    ...ctx,
   };
   return {
     ctx: usedCtx,
@@ -44,6 +41,6 @@ export function usingTestingBoxedExpressionI18nContext(
       <I18nDictionariesProvider defaults={usedCtx.defaults} dictionaries={usedCtx.dictionaries} ctx={usedCtx.ctx}>
         {usedCtx.children}
       </I18nDictionariesProvider>
-    )
+    ),
   };
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/test-setup.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/test-setup.ts
@@ -15,4 +15,3 @@
  */
 
 import "jest-webextension-mock";
-

--- a/kie-wb-common-react/boxed-expression-editor/src/api/DataType.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/DataType.ts
@@ -25,5 +25,5 @@ export enum DataType {
   Number = "number",
   String = "string",
   Time = "time",
-  YearsMonthsDuration = "years and months duration"
+  YearsMonthsDuration = "years and months duration",
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/api/DataType.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/DataType.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export enum DataType {
+  Undefined = "<Undefined>",
+  Any = "Any",
+  Boolean = "boolean",
+  Context = "context",
+  Date = "date",
+  DateTime = "date and time",
+  DateTimeDuration = "days and time duration",
+  Number = "number",
+  String = "string",
+  Time = "time",
+  YearsMonthsDuration = "years and months duration"
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ExpressionProps {
+  expressionName: string | undefined,
+  dataType: string
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -15,6 +15,6 @@
  */
 
 export interface ExpressionProps {
-  expressionName?: string,
-  dataType: string
+  expressionName?: string;
+  dataType: string;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -15,6 +15,6 @@
  */
 
 export interface ExpressionProps {
-  expressionName: string | undefined,
+  expressionName?: string,
   dataType: string
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/api/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./ExpressionProps";
+export * from './DataType';

--- a/kie-wb-common-react/boxed-expression-editor/src/api/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/index.ts
@@ -15,4 +15,4 @@
  */
 
 export * from "./ExpressionProps";
-export * from './DataType';
+export * from "./DataType";

--- a/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
@@ -14,22 +14,24 @@
  * limitations under the License.
  */
 
-import * as React from 'react';
-import '@patternfly/react-core/dist/styles/base.css';
-import {I18nDictionariesProvider} from "@kogito-tooling/i18n/dist/react-components";
-import {ExpressionContainer, ExpressionContainerProps} from "../ExpressionContainer";
+import * as React from "react";
+import "@patternfly/react-core/dist/styles/base.css";
+import { I18nDictionariesProvider } from "@kogito-tooling/i18n/dist/react-components";
+import { ExpressionContainer, ExpressionContainerProps } from "../ExpressionContainer";
 import {
   boxedExpressionEditorDictionaries,
   BoxedExpressionEditorI18nContext,
-  boxedExpressionEditorI18nDefaults
+  boxedExpressionEditorI18nDefaults,
 } from "../../i18n";
 
 export interface BoxedExpressionEditorProps {
   /** All expression properties used to define it */
-  expressionDefinition: ExpressionContainerProps
+  expressionDefinition: ExpressionContainerProps;
 }
 
-const BoxedExpressionEditor: (props: BoxedExpressionEditorProps) => JSX.Element = (props: BoxedExpressionEditorProps) => (
+const BoxedExpressionEditor: (props: BoxedExpressionEditorProps) => JSX.Element = (
+  props: BoxedExpressionEditorProps
+) => (
   <I18nDictionariesProvider
     defaults={boxedExpressionEditorI18nDefaults}
     dictionaries={boxedExpressionEditorDictionaries}
@@ -40,4 +42,4 @@ const BoxedExpressionEditor: (props: BoxedExpressionEditorProps) => JSX.Element 
   </I18nDictionariesProvider>
 );
 
-export {BoxedExpressionEditor};
+export { BoxedExpressionEditor };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './BoxedExpressionEditor';
+export * from "./BoxedExpressionEditor";

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.css
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#edit-expression-menu {
+  display: flex;
+  flex-direction: column;
+  padding-left: 14px;
+  padding-right: 14px;
+  padding-bottom: 10px;
+}
+
+#edit-expression-menu > .expression-data-type {
+  padding-top: 10px;
+}
+
+#edit-expression-menu * {
+  font-size: var(--small-font-size);
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.css
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#edit-expression-menu {
+.edit-expression-menu {
   display: flex;
   flex-direction: column;
   padding-left: 14px;
@@ -22,10 +22,10 @@
   padding-bottom: 10px;
 }
 
-#edit-expression-menu > .expression-data-type {
+.edit-expression-menu > .expression-data-type {
   padding-top: 10px;
 }
 
-#edit-expression-menu * {
+.edit-expression-menu * {
   font-size: var(--small-font-size);
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
@@ -103,7 +103,7 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
     arrowPlacement={arrowPlacement}
     appendTo={appendTo}
     body={
-      <div id="edit-expression-menu">
+      <div className="edit-expression-menu">
         <div className="expression-name">
           <label>{nameField}</label>
           <input type="text" id="expression-name" value={chosenExpressionName}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import './EditExpressionMenu.css';
+import * as React from "react";
+import {useCallback, useState} from "react";
+import {PopoverMenu} from "../PopoverMenu";
+import {useBoxedExpressionEditorI18n} from "../../i18n";
+import {DataType, ExpressionProps} from "../../api";
+import {Select, SelectOption, SelectVariant} from "@patternfly/react-core";
+import * as _ from "lodash";
+
+export interface EditExpressionMenuProps {
+  /** The node where to append the popover content */
+  appendTo?: HTMLElement | ((ref?: HTMLElement) => HTMLElement),
+  /** A function which returns the HTMLElement where the popover's arrow should be placed */
+  arrowPlacement: () => HTMLElement,
+  /** The label for the field 'Name' */
+  nameField?: string,
+  /** The label for the field 'Data Type' */
+  dataTypeField?: string,
+  /** The title of the popover menu */
+  title?: string,
+  /** The pre-selected data type */
+  selectedDataType?: DataType,
+  /** The pre-selected expression name */
+  selectedExpressionName?: string,
+  /** Function to be called when the expression gets updated, passing the most updated version of it */
+  onExpressionUpdate: (expression: ExpressionProps) => void
+}
+
+export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps> = ({
+  appendTo,
+  arrowPlacement,
+  title,
+  nameField,
+  dataTypeField,
+  selectedDataType = DataType.Undefined,
+  selectedExpressionName,
+  onExpressionUpdate
+}: EditExpressionMenuProps) => {
+  const {i18n} = useBoxedExpressionEditorI18n();
+  title = title ?? i18n.editExpression;
+  nameField = nameField ?? i18n.name;
+  dataTypeField = dataTypeField ?? i18n.dataType;
+
+  const [dataTypeSelectIsOpen, setDataTypeSelectOpen] = useState(false);
+  const [chosenDataType, setDataType] = useState(selectedDataType);
+  const [chosenExpressionName, setExpressionName] = useState(selectedExpressionName);
+
+  const onExpressionNameChange = useCallback((event) => {
+    setExpressionName(event.target.value);
+    if (event.type === 'blur') {
+      onExpressionUpdate({
+        expressionName: event.target.value,
+        dataType: chosenDataType
+      });
+    }
+  }, [chosenDataType, onExpressionUpdate]);
+
+  const onDataTypeSelect = useCallback((event, selection) => {
+    setDataTypeSelectOpen(false);
+    setDataType(selection);
+    onExpressionUpdate({
+      expressionName: chosenExpressionName,
+      dataType: selection
+    });
+  }, [chosenExpressionName, onExpressionUpdate]);
+
+  const getDataTypes = useCallback(() => {
+    return _.map(Object.values(DataType), key => <SelectOption key={key} value={key}>{key}</SelectOption>)
+  }, []);
+
+  const onDataTypeFilter = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      let input: RegExp;
+      try {
+        input = new RegExp(e.target.value, 'i');
+      } catch (exception) {
+        return getDataTypes();
+      }
+      return e.target.value !== '' ? getDataTypes().filter(child => input.test(child.props.value)) : getDataTypes();
+    },[getDataTypes]
+  );
+
+  const onDataTypeSelectToggle = useCallback(isOpen => setDataTypeSelectOpen(isOpen), []);
+
+  return <PopoverMenu
+    title={title}
+    arrowPlacement={arrowPlacement}
+    appendTo={appendTo}
+    body={
+      <div id="edit-expression-menu">
+        <div className="expression-name">
+          <label>{nameField}</label>
+          <input type="text" id="expression-name" value={chosenExpressionName}
+                 onChange={onExpressionNameChange} onBlur={onExpressionNameChange}
+                 className="form-control pf-c-form-control" placeholder="Expression Name"/>
+        </div>
+        <div className="expression-data-type">
+          <label>{dataTypeField}</label>
+          <Select
+            variant={SelectVariant.typeahead}
+            typeAheadAriaLabel={i18n.choose}
+            onToggle={onDataTypeSelectToggle}
+            onSelect={onDataTypeSelect}
+            onFilter={onDataTypeFilter}
+            isOpen={dataTypeSelectIsOpen}
+            selections={chosenDataType}
+            hasInlineFilter
+            inlineFilterPlaceholderText={i18n.choose}
+          >
+            {getDataTypes()}
+          </Select>
+        </div>
+      </div>
+    }
+  />;
+};

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
@@ -14,32 +14,32 @@
  * limitations under the License.
  */
 
-import './EditExpressionMenu.css';
+import "./EditExpressionMenu.css";
 import * as React from "react";
-import {useCallback, useState} from "react";
-import {PopoverMenu} from "../PopoverMenu";
-import {useBoxedExpressionEditorI18n} from "../../i18n";
-import {DataType, ExpressionProps} from "../../api";
-import {Select, SelectOption, SelectVariant} from "@patternfly/react-core";
+import { useCallback, useState } from "react";
+import { PopoverMenu } from "../PopoverMenu";
+import { useBoxedExpressionEditorI18n } from "../../i18n";
+import { DataType, ExpressionProps } from "../../api";
+import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";
 import * as _ from "lodash";
 
 export interface EditExpressionMenuProps {
   /** The node where to append the popover content */
-  appendTo?: HTMLElement | ((ref?: HTMLElement) => HTMLElement),
+  appendTo?: HTMLElement | ((ref?: HTMLElement) => HTMLElement);
   /** A function which returns the HTMLElement where the popover's arrow should be placed */
-  arrowPlacement: () => HTMLElement,
+  arrowPlacement: () => HTMLElement;
   /** The label for the field 'Name' */
-  nameField?: string,
+  nameField?: string;
   /** The label for the field 'Data Type' */
-  dataTypeField?: string,
+  dataTypeField?: string;
   /** The title of the popover menu */
-  title?: string,
+  title?: string;
   /** The pre-selected data type */
-  selectedDataType?: DataType,
+  selectedDataType?: DataType;
   /** The pre-selected expression name */
-  selectedExpressionName?: string,
+  selectedExpressionName?: string;
   /** Function to be called when the expression gets updated, passing the most updated version of it */
-  onExpressionUpdate: (expression: ExpressionProps) => void
+  onExpressionUpdate: (expression: ExpressionProps) => void;
 }
 
 export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps> = ({
@@ -50,9 +50,9 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
   dataTypeField,
   selectedDataType = DataType.Undefined,
   selectedExpressionName,
-  onExpressionUpdate
+  onExpressionUpdate,
 }: EditExpressionMenuProps) => {
-  const {i18n} = useBoxedExpressionEditorI18n();
+  const { i18n } = useBoxedExpressionEditorI18n();
   title = title ?? i18n.editExpression;
   nameField = nameField ?? i18n.name;
   dataTypeField = dataTypeField ?? i18n.dataType;
@@ -61,72 +61,91 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
   const [chosenDataType, setDataType] = useState(selectedDataType);
   const [chosenExpressionName, setExpressionName] = useState(selectedExpressionName);
 
-  const onExpressionNameChange = useCallback((event) => {
-    setExpressionName(event.target.value);
-    if (event.type === 'blur') {
-      onExpressionUpdate({
-        expressionName: event.target.value,
-        dataType: chosenDataType
-      });
-    }
-  }, [chosenDataType, onExpressionUpdate]);
+  const onExpressionNameChange = useCallback(
+    (event) => {
+      setExpressionName(event.target.value);
+      if (event.type === "blur") {
+        onExpressionUpdate({
+          expressionName: event.target.value,
+          dataType: chosenDataType,
+        });
+      }
+    },
+    [chosenDataType, onExpressionUpdate]
+  );
 
-  const onDataTypeSelect = useCallback((event, selection) => {
-    setDataTypeSelectOpen(false);
-    setDataType(selection);
-    onExpressionUpdate({
-      expressionName: chosenExpressionName,
-      dataType: selection
-    });
-  }, [chosenExpressionName, onExpressionUpdate]);
+  const onDataTypeSelect = useCallback(
+    (event, selection) => {
+      setDataTypeSelectOpen(false);
+      setDataType(selection);
+      onExpressionUpdate({
+        expressionName: chosenExpressionName,
+        dataType: selection,
+      });
+    },
+    [chosenExpressionName, onExpressionUpdate]
+  );
 
   const getDataTypes = useCallback(() => {
-    return _.map(Object.values(DataType), key => <SelectOption key={key} value={key}>{key}</SelectOption>)
+    return _.map(Object.values(DataType), (key) => (
+      <SelectOption key={key} value={key}>
+        {key}
+      </SelectOption>
+    ));
   }, []);
 
   const onDataTypeFilter = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       let input: RegExp;
       try {
-        input = new RegExp(e.target.value, 'i');
+        input = new RegExp(e.target.value, "i");
       } catch (exception) {
         return getDataTypes();
       }
-      return e.target.value !== '' ? getDataTypes().filter(child => input.test(child.props.value)) : getDataTypes();
-    },[getDataTypes]
+      return e.target.value !== "" ? getDataTypes().filter((child) => input.test(child.props.value)) : getDataTypes();
+    },
+    [getDataTypes]
   );
 
-  const onDataTypeSelectToggle = useCallback(isOpen => setDataTypeSelectOpen(isOpen), []);
+  const onDataTypeSelectToggle = useCallback((isOpen) => setDataTypeSelectOpen(isOpen), []);
 
-  return <PopoverMenu
-    title={title}
-    arrowPlacement={arrowPlacement}
-    appendTo={appendTo}
-    body={
-      <div className="edit-expression-menu">
-        <div className="expression-name">
-          <label>{nameField}</label>
-          <input type="text" id="expression-name" value={chosenExpressionName}
-                 onChange={onExpressionNameChange} onBlur={onExpressionNameChange}
-                 className="form-control pf-c-form-control" placeholder="Expression Name"/>
+  return (
+    <PopoverMenu
+      title={title}
+      arrowPlacement={arrowPlacement}
+      appendTo={appendTo}
+      body={
+        <div className="edit-expression-menu">
+          <div className="expression-name">
+            <label>{nameField}</label>
+            <input
+              type="text"
+              id="expression-name"
+              value={chosenExpressionName}
+              onChange={onExpressionNameChange}
+              onBlur={onExpressionNameChange}
+              className="form-control pf-c-form-control"
+              placeholder="Expression Name"
+            />
+          </div>
+          <div className="expression-data-type">
+            <label>{dataTypeField}</label>
+            <Select
+              variant={SelectVariant.typeahead}
+              typeAheadAriaLabel={i18n.choose}
+              onToggle={onDataTypeSelectToggle}
+              onSelect={onDataTypeSelect}
+              onFilter={onDataTypeFilter}
+              isOpen={dataTypeSelectIsOpen}
+              selections={chosenDataType}
+              hasInlineFilter
+              inlineFilterPlaceholderText={i18n.choose}
+            >
+              {getDataTypes()}
+            </Select>
+          </div>
         </div>
-        <div className="expression-data-type">
-          <label>{dataTypeField}</label>
-          <Select
-            variant={SelectVariant.typeahead}
-            typeAheadAriaLabel={i18n.choose}
-            onToggle={onDataTypeSelectToggle}
-            onSelect={onDataTypeSelect}
-            onFilter={onDataTypeFilter}
-            isOpen={dataTypeSelectIsOpen}
-            selections={chosenDataType}
-            hasInlineFilter
-            inlineFilterPlaceholderText={i18n.choose}
-          >
-            {getDataTypes()}
-          </Select>
-        </div>
-      </div>
-    }
-  />;
+      }
+    />
+  );
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './EditExpressionMenu';

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './EditExpressionMenu';
+export * from "./EditExpressionMenu";

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
@@ -46,7 +46,7 @@
 }
 
 #expression-actions .pf-c-dropdown a {
-  font-size: 13px;
+  font-size: var(--small-font-size);
 }
 
 .expression-container #expression-actions .pf-c-dropdown button:focus {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
@@ -40,35 +40,11 @@
   color: gray;
 }
 
-.expression-selector-menu .pf-c-button {
-  display: none;
-}
-
-.expression-selector-menu .pf-c-popover__content,
-.expression-selector-menu .pf-c-title,
-.expression-selector-menu .pf-c-popover__content > .pf-c-button + *,
 #expression-actions .pf-c-dropdown .pf-c-dropdown__menu,
 #expression-actions-toggle {
   padding: 0;
 }
 
-.expression-selector-menu .pf-c-title .selector-menu-title {
-  border-bottom: none;
-  border-radius: 0;
-  color: #4d5258;
-  font-weight: 700;
-  min-height: 34px;
-  margin: 0;
-  padding: 8px 14px;
-}
-
-.expression-selector-menu .pf-c-title .selector-menu-title,
-.expression-selector-menu .pf-c-popover__arrow {
-  background-color: #f5f5f5;
-}
-
-.expression-selector-menu .pf-c-title .selector-menu-title,
-.expression-selector-menu .pf-c-simple-list button,
 #expression-actions .pf-c-dropdown a {
   font-size: 13px;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -15,40 +15,45 @@
  */
 
 import * as React from "react";
-import {useCallback, useState} from "react";
+import { useCallback, useState } from "react";
 import * as _ from "lodash";
-import "./ExpressionContainer.css"
-import {useBoxedExpressionEditorI18n} from "../../i18n";
+import "./ExpressionContainer.css";
+import { useBoxedExpressionEditorI18n } from "../../i18n";
 import {
   Dropdown,
   DropdownItem,
   KebabToggle,
   SimpleList,
   SimpleListItem,
-  SimpleListItemProps
+  SimpleListItemProps,
 } from "@patternfly/react-core";
-import {PopoverMenu} from "../PopoverMenu";
+import { PopoverMenu } from "../PopoverMenu";
 
 export interface ExpressionContainerProps {
   /** The name of the expression */
-  name: string,
+  name: string;
   /** The type of the expression */
-  type?: string,
+  type?: string;
   /** Selected expression is already present */
-  selectedExpression?: string
+  selectedExpression?: string;
 }
 
-export const ExpressionContainer: (props: ExpressionContainerProps) => JSX.Element = (props: ExpressionContainerProps) => {
-  const {i18n} = useBoxedExpressionEditorI18n();
+export const ExpressionContainer: (props: ExpressionContainerProps) => JSX.Element = (
+  props: ExpressionContainerProps
+) => {
+  const { i18n } = useBoxedExpressionEditorI18n();
 
   const [logicTypeIsPresent, setLogicTypeSelected] = useState(!_.isEmpty(props.selectedExpression));
   const [actionDropdownIsOpen, setActionDropDownOpen] = useState(false);
   const [selectedExpression, setSelectedExpression] = useState(props.selectedExpression || i18n.selectExpression);
 
-  const onLogicTypeSelect = useCallback((currentItem: React.RefObject<HTMLButtonElement>, currentItemProps: SimpleListItemProps) => {
-    setLogicTypeSelected(true);
-    setSelectedExpression(currentItemProps.children as string);
-  }, []);
+  const onLogicTypeSelect = useCallback(
+    (currentItem: React.RefObject<HTMLButtonElement>, currentItemProps: SimpleListItemProps) => {
+      setLogicTypeSelected(true);
+      setSelectedExpression(currentItemProps.children as string);
+    },
+    []
+  );
 
   const executeClearAction = useCallback(() => {
     setLogicTypeSelected(false);
@@ -56,60 +61,60 @@ export const ExpressionContainer: (props: ExpressionContainerProps) => JSX.Eleme
   }, [i18n.selectExpression]);
 
   const renderExpressionActionsDropdown = () => {
-    return <Dropdown
-      onSelect={() => setActionDropDownOpen(!actionDropdownIsOpen)}
-      toggle={<KebabToggle onToggle={isOpen => setActionDropDownOpen(isOpen)} id="expression-actions-toggle"/>}
-      isOpen={actionDropdownIsOpen}
-      isPlain
-      dropdownItems={[
-        <DropdownItem key="clear" onClick={executeClearAction} isDisabled={!logicTypeIsPresent}>
-          {i18n.clear}
-        </DropdownItem>
-      ]}
-    />;
+    return (
+      <Dropdown
+        onSelect={() => setActionDropDownOpen(!actionDropdownIsOpen)}
+        toggle={<KebabToggle onToggle={(isOpen) => setActionDropDownOpen(isOpen)} id="expression-actions-toggle" />}
+        isOpen={actionDropdownIsOpen}
+        isPlain
+        dropdownItems={[
+          <DropdownItem key="clear" onClick={executeClearAction} isDisabled={!logicTypeIsPresent}>
+            {i18n.clear}
+          </DropdownItem>,
+        ]}
+      />
+    );
   };
 
   const buildLogicSelectorMenu = () => {
-    return <PopoverMenu
-      title={i18n.selectLogicType}
-      arrowPlacement={() => document.getElementById("expression-container-box")!}
-      body={
-        <SimpleList onSelect={onLogicTypeSelect}>
-          {renderLogicTypeItems()}
-        </SimpleList>
-      }
-    />;
+    return (
+      <PopoverMenu
+        title={i18n.selectLogicType}
+        arrowPlacement={() => document.getElementById("expression-container-box")!}
+        body={<SimpleList onSelect={onLogicTypeSelect}>{renderLogicTypeItems()}</SimpleList>}
+      />
+    );
   };
 
   const renderLogicTypeItems = () => {
-    return _.map([
-      i18n.literalExpression,
-      i18n.context,
-      i18n.decisionTable,
-      i18n.relation,
-      i18n.function,
-      i18n.invocation,
-      i18n.list,
-    ], key => <SimpleListItem key={key}>{key}</SimpleListItem>)
+    return _.map(
+      [
+        i18n.literalExpression,
+        i18n.context,
+        i18n.decisionTable,
+        i18n.relation,
+        i18n.function,
+        i18n.invocation,
+        i18n.list,
+      ],
+      (key) => <SimpleListItem key={key}>{key}</SimpleListItem>
+    );
   };
 
   return (
     <div className="expression-container">
-      <span id="expression-title">
-        {props.name || ''}
-      </span>
-      <span id="expression-type">
-        ({props.type ?? '<Undefined>'})
-      </span>
-      <span id="expression-actions">
-        {renderExpressionActionsDropdown()}
-      </span>
+      <span id="expression-title">{props.name || ""}</span>
+      <span id="expression-type">({props.type ?? "<Undefined>"})</span>
+      <span id="expression-actions">{renderExpressionActionsDropdown()}</span>
 
-      <div id="expression-container-box" className={logicTypeIsPresent ? 'logic-type-selected' : 'logic-type-not-present'}>
+      <div
+        id="expression-container-box"
+        className={logicTypeIsPresent ? "logic-type-selected" : "logic-type-not-present"}
+      >
         {selectedExpression}
       </div>
 
-      { !logicTypeIsPresent ? buildLogicSelectorMenu() : null }
+      {!logicTypeIsPresent ? buildLogicSelectorMenu() : null}
     </div>
   );
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -23,11 +23,11 @@ import {
   Dropdown,
   DropdownItem,
   KebabToggle,
-  Popover,
   SimpleList,
   SimpleListItem,
   SimpleListItemProps
 } from "@patternfly/react-core";
+import {PopoverMenu} from "../PopoverMenu";
 
 export interface ExpressionContainerProps {
   /** The name of the expression */
@@ -38,24 +38,17 @@ export interface ExpressionContainerProps {
   selectedExpression?: string
 }
 
-const ExpressionContainer: (props: ExpressionContainerProps) => JSX.Element = (props: ExpressionContainerProps) => {
+export const ExpressionContainer: (props: ExpressionContainerProps) => JSX.Element = (props: ExpressionContainerProps) => {
   const {i18n} = useBoxedExpressionEditorI18n();
 
   const [logicTypeIsPresent, setLogicTypeSelected] = useState(!_.isEmpty(props.selectedExpression));
   const [actionDropdownIsOpen, setActionDropDownOpen] = useState(false);
   const [selectedExpression, setSelectedExpression] = useState(props.selectedExpression || i18n.selectExpression);
 
-  const hideSelectorMenuPopover = useCallback(() => {
-    const elem = document.querySelector('.expression-selector-menu .pf-c-button');
-    const button: HTMLButtonElement = elem as HTMLButtonElement;
-    return button.click();
-  }, []);
-
   const onLogicTypeSelect = useCallback((currentItem: React.RefObject<HTMLButtonElement>, currentItemProps: SimpleListItemProps) => {
     setLogicTypeSelected(true);
     setSelectedExpression(currentItemProps.children as string);
-    hideSelectorMenuPopover();
-  }, [hideSelectorMenuPopover]);
+  }, []);
 
   const executeClearAction = useCallback(() => {
     setLogicTypeSelected(false);
@@ -77,20 +70,10 @@ const ExpressionContainer: (props: ExpressionContainerProps) => JSX.Element = (p
   };
 
   const buildLogicSelectorMenu = () => {
-    return <Popover
-      className="expression-selector-menu"
-      position="bottom"
-      distance={0}
-      reference={() => document.getElementById("expression-container-box")!}
-      isVisible={false}
-      shouldOpen={(showFunction = _.identity) => {
-        if (!logicTypeIsPresent) {
-          showFunction();
-        }
-      }}
-      shouldClose={(tip, hideFunction = _.identity) => hideFunction()}
-      headerContent={<div className="selector-menu-title">{i18n.selectLogicType}</div>}
-      bodyContent={
+    return <PopoverMenu
+      title={i18n.selectLogicType}
+      arrowPlacement={() => document.getElementById("expression-container-box")!}
+      body={
         <SimpleList onSelect={onLogicTypeSelect}>
           {renderLogicTypeItems()}
         </SimpleList>
@@ -126,9 +109,7 @@ const ExpressionContainer: (props: ExpressionContainerProps) => JSX.Element = (p
         {selectedExpression}
       </div>
 
-      {buildLogicSelectorMenu()}
+      { !logicTypeIsPresent ? buildLogicSelectorMenu() : null }
     </div>
   );
-}
-
-export {ExpressionContainer};
+};

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './ExpressionContainer';
+export * from "./ExpressionContainer";

--- a/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/PopoverMenu.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/PopoverMenu.css
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.popover-menu-selector .pf-c-button {
+  display: none;
+}
+
+.popover-menu-selector .pf-c-popover__content,
+.popover-menu-selector .pf-c-title,
+.popover-menu-selector .pf-c-popover__content > .pf-c-button + * {
+  padding: 0;
+}
+
+.popover-menu-selector .pf-c-title .selector-menu-title {
+  border-bottom: none;
+  border-radius: 0;
+  color: #4d5258;
+  font-weight: 700;
+  min-height: 34px;
+  margin: 0;
+  padding: 8px 14px;
+}
+
+.popover-menu-selector .pf-c-title .selector-menu-title,
+.popover-menu-selector .pf-c-popover__arrow {
+  background-color: #f5f5f5;
+}
+
+.popover-menu-selector .pf-c-title .selector-menu-title,
+.popover-menu-selector .pf-c-simple-list button {
+  font-size: 13px;
+  font-style: normal;
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/PopoverMenu.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/PopoverMenu.css
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-.popover-menu-selector .pf-c-button {
+.pf-c-popover__content > .pf-c-button {
   display: none;
 }
 
@@ -41,6 +41,6 @@
 
 .popover-menu-selector .pf-c-title .selector-menu-title,
 .popover-menu-selector .pf-c-simple-list button {
-  font-size: 13px;
+  font-size: var(--small-font-size);
   font-style: normal;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/PopoverMenu.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/PopoverMenu.tsx
@@ -15,8 +15,8 @@
  */
 
 import * as React from "react";
-import {Popover} from "@patternfly/react-core";
-import "./PopoverMenu.css"
+import { Popover } from "@patternfly/react-core";
+import "./PopoverMenu.css";
 
 export interface PopoverMenuProps {
   /** Title of the popover menu */
@@ -33,15 +33,18 @@ export const PopoverMenu: React.FunctionComponent<PopoverMenuProps> = ({
   arrowPlacement,
   body,
   title,
-  appendTo
+  appendTo,
 }: PopoverMenuProps) => {
-  return <Popover
-    className="popover-menu-selector"
-    position="bottom"
-    distance={0}
-    id="menu-selector"
-    reference={arrowPlacement}
-    appendTo={appendTo}
-    headerContent={<div className="selector-menu-title">{title}</div>}
-    bodyContent={body}/>;
+  return (
+    <Popover
+      className="popover-menu-selector"
+      position="bottom"
+      distance={0}
+      id="menu-selector"
+      reference={arrowPlacement}
+      appendTo={appendTo}
+      headerContent={<div className="selector-menu-title">{title}</div>}
+      bodyContent={body}
+    />
+  );
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/PopoverMenu.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/PopoverMenu.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import {Popover} from "@patternfly/react-core";
+import "./PopoverMenu.css"
+
+export interface PopoverMenuProps {
+  /** Title of the popover menu */
+  title: string;
+  /** A function which returns the HTMLElement where the popover's arrow should be placed */
+  arrowPlacement: () => HTMLElement;
+  /** The content of the popover itself */
+  body: React.ReactNode;
+}
+
+export const PopoverMenu: React.FunctionComponent<PopoverMenuProps> = ({
+  arrowPlacement,
+  body,
+  title
+}: PopoverMenuProps) => {
+  return <Popover
+    className="popover-menu-selector"
+    position="bottom"
+    distance={0}
+    id="menu-selector"
+    reference={arrowPlacement}
+    appendTo={arrowPlacement}
+    headerContent={<div className="selector-menu-title">{title}</div>}
+    bodyContent={body}/>;
+};

--- a/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/PopoverMenu.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/PopoverMenu.tsx
@@ -25,12 +25,15 @@ export interface PopoverMenuProps {
   arrowPlacement: () => HTMLElement;
   /** The content of the popover itself */
   body: React.ReactNode;
+  /** The node where to append the popover content */
+  appendTo?: HTMLElement | ((ref?: HTMLElement) => HTMLElement);
 }
 
 export const PopoverMenu: React.FunctionComponent<PopoverMenuProps> = ({
   arrowPlacement,
   body,
-  title
+  title,
+  appendTo
 }: PopoverMenuProps) => {
   return <Popover
     className="popover-menu-selector"
@@ -38,7 +41,7 @@ export const PopoverMenu: React.FunctionComponent<PopoverMenuProps> = ({
     distance={0}
     id="menu-selector"
     reference={arrowPlacement}
-    appendTo={arrowPlacement}
+    appendTo={appendTo}
     headerContent={<div className="selector-menu-title">{title}</div>}
     bodyContent={body}/>;
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './PopoverMenu';

--- a/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './PopoverMenu';
+export * from "./PopoverMenu";

--- a/kie-wb-common-react/boxed-expression-editor/src/components/index.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/index.css
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
-import './index.css';
-export * from './BoxedExpressionEditor';
-export * from './ExpressionContainer';
+:root {
+  --small-font-size: 13px;
+}
+

--- a/kie-wb-common-react/boxed-expression-editor/src/components/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import './index.css';
-export * from './BoxedExpressionEditor';
-export * from './ExpressionContainer';
+import "./index.css";
+export * from "./BoxedExpressionEditor";
+export * from "./ExpressionContainer";

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/BoxedExpressionEditorI18n.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/BoxedExpressionEditorI18n.ts
@@ -18,16 +18,20 @@ import { ReferenceDictionary } from "@kogito-tooling/i18n/dist/core";
 import { CommonI18n } from "@kogito-tooling/i18n-common-dictionary";
 
 interface BoxedExpressionEditorDictionary extends ReferenceDictionary<BoxedExpressionEditorDictionary> {
-  selectExpression: string;
-  selectLogicType: string;
+  choose: string;
   clear: string;
-  literalExpression: string;
   context: string;
+  dataType: string;
   decisionTable: string;
-  relation: string;
+  editExpression: string;
   function: string;
   invocation: string;
   list: string;
+  literalExpression: string;
+  name: string;
+  relation: string;
+  selectExpression: string;
+  selectLogicType: string;
 }
 
 export interface BoxedExpressionEditorI18n extends BoxedExpressionEditorDictionary, CommonI18n {}

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
@@ -32,5 +32,5 @@ export const en: BoxedExpressionEditorI18n = {
   function: "Function",
   invocation: "Invocation",
   list: "List",
-  clear: "Clear"
+  clear: "Clear",
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
@@ -18,6 +18,10 @@ import { BoxedExpressionEditorI18n } from "..";
 import { en as en_common } from "@kogito-tooling/i18n-common-dictionary";
 
 export const en: BoxedExpressionEditorI18n = {
+  choose: "Choose...",
+  editExpression: "Edit Expression",
+  name: "Name",
+  dataType: "Data Type",
   ...en_common,
   selectExpression: "Select expression",
   selectLogicType: "Select logic type",

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/setup.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/setup.ts
@@ -21,9 +21,14 @@ import { I18nContextType } from "@kogito-tooling/i18n/dist/react-components";
 import { BoxedExpressionEditorI18n } from "./BoxedExpressionEditorI18n";
 import { I18nDefaults, I18nDictionaries } from "@kogito-tooling/i18n/dist/core";
 
-export const boxedExpressionEditorI18nDefaults: I18nDefaults<BoxedExpressionEditorI18n> = { locale: "en", dictionary: en };
+export const boxedExpressionEditorI18nDefaults: I18nDefaults<BoxedExpressionEditorI18n> = {
+  locale: "en",
+  dictionary: en,
+};
 export const boxedExpressionEditorDictionaries: I18nDictionaries<BoxedExpressionEditorI18n> = new Map([["en", en]]);
-export const BoxedExpressionEditorI18nContext = React.createContext<I18nContextType<BoxedExpressionEditorI18n>>({} as never);
+export const BoxedExpressionEditorI18nContext = React.createContext<I18nContextType<BoxedExpressionEditorI18n>>(
+  {} as never
+);
 
 export function useBoxedExpressionEditorI18n(): I18nContextType<BoxedExpressionEditorI18n> {
   return useContext(BoxedExpressionEditorI18nContext);

--- a/kie-wb-common-react/boxed-expression-editor/src/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './components';
+export * from "./components";

--- a/kie-wb-common-react/boxed-expression-editor/yarn.lock
+++ b/kie-wb-common-react/boxed-expression-editor/yarn.lock
@@ -2963,6 +2963,20 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^6.15.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz#7f93f6cb7d45a92f1537a70ecc06366e1ac6fed9"
+  integrity sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==
+  dependencies:
+    get-stdin "^6.0.0"
+
+eslint-plugin-prettier@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2"
+  integrity sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-plugin-react-hooks@^4.1.2:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
@@ -3312,6 +3326,11 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+
 fast-glob@^3.0.3, fast-glob@^3.1.1, fast-glob@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
@@ -3629,6 +3648,11 @@ get-intrinsic@^1.0.0:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -6668,6 +6692,13 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
 
 prettier@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/KOGITO-3630

_Preview of the component_
![image](https://user-images.githubusercontent.com/22591802/99990084-b096c980-2db3-11eb-8426-2d0c834a0d6e.png)
 _Brief architectural overview_
We are going to have several `Popover` instances in the editor, very similar to each other. So I created the `PopoverMenu` component as common base.
For instance, we will have the `SelectLogicTypeMenu` (in one of the next PRs) that will be used both in the `ExpressionContainer` and in every recursive Expression structure.
Regarding this PR, The `EditExpressionMenu` component will be used every time we need to have a popover with a "Name" to fill (input text) and a "Data type" to select (select box)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
