### PR TITLE
KOGITO-3631: Create "LiteralExpression" component

### DIFF
--- a/kie-wb-common-react/boxed-expression-editor/.editorconfig
+++ b/kie-wb-common-react/boxed-expression-editor/.editorconfig
@@ -7,6 +7,9 @@ indent_style = space
 indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
+ij_typescript_spaces_within_imports = true
+ij_javascript_spaces_within_imports = true
+ij_typescript_spaces_within_object_literal_braces = true
 
 [*.snap]
 max_line_length = off

--- a/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
@@ -17,8 +17,12 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import './index.css';
-import {BoxedExpressionEditor, ExpressionContainerProps} from "./boxed_expression_editor";
+import { BoxedExpressionEditor, DataType, ExpressionContainerProps } from "./boxed_expression_editor";
 
-const expressionDefinition: ExpressionContainerProps = {'decisionName': 'Expression Name'};
+const selectedExpression = {
+  'name': 'Expression Name',
+  'dataType': DataType.Undefined,
+};
+const expressionDefinition: ExpressionContainerProps = {'selectedExpression': selectedExpression};
 
 ReactDOM.render(<BoxedExpressionEditor expressionDefinition={expressionDefinition}/>, document.getElementById('root'));

--- a/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
@@ -19,6 +19,6 @@ import * as ReactDOM from "react-dom";
 import './index.css';
 import {BoxedExpressionEditor, ExpressionContainerProps} from "./boxed_expression_editor";
 
-const expressionDefinition: ExpressionContainerProps = {'name': 'Expression Name'};
+const expressionDefinition: ExpressionContainerProps = {'decisionName': 'Expression Name'};
 
 ReactDOM.render(<BoxedExpressionEditor expressionDefinition={expressionDefinition}/>, document.getElementById('root'));

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/BoxedExpressionEditor.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/BoxedExpressionEditor.test.tsx
@@ -18,11 +18,11 @@ import * as React from "react";
 import { render } from "@testing-library/react";
 import { BoxedExpressionEditor } from "../../../components/BoxedExpressionEditor";
 import { ExpressionContainerProps } from "../../../components/ExpressionContainer";
-import { ExpressionProps } from "../../../api";
+import { DataType, ExpressionProps } from "../../../api";
 
 describe("BoxedExpressionEditor tests", () => {
   test("should render BoxedExpressionEditor component", () => {
-    const selectedExpression: ExpressionProps = { name: "Expression Name" };
+    const selectedExpression: ExpressionProps = { name: "Expression Name", dataType: DataType.Undefined };
     const expressionDefinition: ExpressionContainerProps = { selectedExpression: selectedExpression };
 
     const { container } = render(<BoxedExpressionEditor expressionDefinition={expressionDefinition} />);

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/BoxedExpressionEditor.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/BoxedExpressionEditor.test.tsx
@@ -21,7 +21,7 @@ import { ExpressionContainerProps } from "../../../components/ExpressionContaine
 
 describe("BoxedExpressionEditor tests", () => {
   test("should render BoxedExpressionEditor component", () => {
-    const expressionDefinition: ExpressionContainerProps = { name: "Expression Name" };
+    const expressionDefinition: ExpressionContainerProps = { decisionName: "Expression Name" };
     const { container } = render(<BoxedExpressionEditor expressionDefinition={expressionDefinition} />);
     expect(container).toMatchSnapshot();
   });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/BoxedExpressionEditor.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/BoxedExpressionEditor.test.tsx
@@ -18,11 +18,15 @@ import * as React from "react";
 import { render } from "@testing-library/react";
 import { BoxedExpressionEditor } from "../../../components/BoxedExpressionEditor";
 import { ExpressionContainerProps } from "../../../components/ExpressionContainer";
+import { ExpressionProps } from "../../../api";
 
 describe("BoxedExpressionEditor tests", () => {
   test("should render BoxedExpressionEditor component", () => {
-    const expressionDefinition: ExpressionContainerProps = { decisionName: "Expression Name" };
+    const selectedExpression: ExpressionProps = { name: "Expression Name" };
+    const expressionDefinition: ExpressionContainerProps = { selectedExpression: selectedExpression };
+
     const { container } = render(<BoxedExpressionEditor expressionDefinition={expressionDefinition} />);
+
     expect(container).toMatchSnapshot();
   });
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/__snapshots__/BoxedExpressionEditor.test.tsx.snap
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/__snapshots__/BoxedExpressionEditor.test.tsx.snap
@@ -6,19 +6,19 @@ exports[`BoxedExpressionEditor tests should render BoxedExpressionEditor compone
     class="expression-container"
   >
     <span
-      id="expression-title"
+      class="expression-title"
     >
       Expression Name
     </span>
     <span
-      id="expression-type"
+      class="expression-type"
     >
       (
       &lt;Undefined&gt;
       )
     </span>
     <span
-      id="expression-actions"
+      class="expression-actions"
     >
       <div
         class="pf-c-dropdown"
@@ -30,8 +30,8 @@ exports[`BoxedExpressionEditor tests should render BoxedExpressionEditor compone
           aria-expanded="false"
           aria-haspopup="true"
           aria-label="Actions"
-          class="pf-c-dropdown__toggle pf-m-plain"
-          id="expression-actions-toggle"
+          class="pf-c-dropdown__toggle pf-m-plain expression-actions-toggle"
+          id="pf-dropdown-toggle-id-0"
           type="button"
         >
           <svg
@@ -51,8 +51,7 @@ exports[`BoxedExpressionEditor tests should render BoxedExpressionEditor compone
       </div>
     </span>
     <div
-      class="logic-type-not-present"
-      id="expression-container-box"
+      class="expression-container-box logic-type-not-present"
     >
       Select expression
     </div>

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/EditExpressionMenu/EditExpressionMenu.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/EditExpressionMenu/EditExpressionMenu.test.tsx
@@ -21,6 +21,7 @@ import { EditExpressionMenu } from "../../../components/EditExpressionMenu";
 import { activatePopover } from "../PopoverMenu/PopoverMenu.test";
 import { DataType, ExpressionProps } from "../../../api";
 import * as _ from "lodash";
+import { LogicType } from "../../../api/LogicType";
 
 jest.useFakeTimers();
 
@@ -116,7 +117,9 @@ describe("EditExpressionMenu tests", () => {
     await activatePopover(container);
 
     expect(container.querySelector("[id^='pf-select-toggle-id-']")).toBeTruthy();
-    expect((container.querySelector("[id^='pf-select-toggle-id-']")! as HTMLInputElement).value).toBe("<Undefined>");
+    expect((container.querySelector("[id^='pf-select-toggle-id-']")! as HTMLInputElement).value).toBe(
+      LogicType.Undefined
+    );
   });
 
   test("should render passed data type, when it is pre-selected", async () => {

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/EditExpressionMenu/EditExpressionMenu.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/EditExpressionMenu/EditExpressionMenu.test.tsx
@@ -19,9 +19,8 @@ import { usingTestingBoxedExpressionI18nContext } from "../test-utils";
 import * as React from "react";
 import { EditExpressionMenu } from "../../../components/EditExpressionMenu";
 import { activatePopover } from "../PopoverMenu/PopoverMenu.test";
-import { DataType, Expression } from "../../../api";
+import { DataType, ExpressionProps, LogicType } from "../../../api";
 import * as _ from "lodash";
-import { LogicType } from "../../../api/LogicType";
 
 jest.useFakeTimers();
 
@@ -176,7 +175,7 @@ describe("EditExpressionMenu tests", () => {
   });
 
   test("should trigger the onExpressionUpdate callback when the expression name is changed", async () => {
-    const onExpressionUpdate = (expression: Expression) => {
+    const onExpressionUpdate = (expression: ExpressionProps) => {
       _.identity(expression);
     };
     const mockedOnExpressionUpdate = jest.fn(onExpressionUpdate);

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/EditExpressionMenu/EditExpressionMenu.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/EditExpressionMenu/EditExpressionMenu.test.tsx
@@ -19,7 +19,7 @@ import { usingTestingBoxedExpressionI18nContext } from "../test-utils";
 import * as React from "react";
 import { EditExpressionMenu } from "../../../components/EditExpressionMenu";
 import { activatePopover } from "../PopoverMenu/PopoverMenu.test";
-import { DataType, ExpressionProps } from "../../../api";
+import { DataType, Expression } from "../../../api";
 import * as _ from "lodash";
 import { LogicType } from "../../../api/LogicType";
 
@@ -33,6 +33,7 @@ describe("EditExpressionMenu tests", () => {
         <div>
           <div id="container">Popover</div>
           <EditExpressionMenu
+            selectedExpressionName="Expression Name"
             title={title}
             arrowPlacement={() => document.getElementById("container")!}
             appendTo={() => document.getElementById("container")!}
@@ -57,6 +58,7 @@ describe("EditExpressionMenu tests", () => {
         <div>
           <div id="container">Popover</div>
           <EditExpressionMenu
+            selectedExpressionName="Expression Name"
             nameField={nameFieldLabel}
             arrowPlacement={() => document.getElementById("container")!}
             appendTo={() => document.getElementById("container")!}
@@ -81,6 +83,7 @@ describe("EditExpressionMenu tests", () => {
         <div>
           <div id="container">Popover</div>
           <EditExpressionMenu
+            selectedExpressionName="Expression Name"
             dataTypeField={dataTypeFieldLabel}
             arrowPlacement={() => document.getElementById("container")!}
             appendTo={() => document.getElementById("container")!}
@@ -104,6 +107,7 @@ describe("EditExpressionMenu tests", () => {
         <div>
           <div id="container">Popover</div>
           <EditExpressionMenu
+            selectedExpressionName="Expression Name"
             arrowPlacement={() => document.getElementById("container")!}
             appendTo={() => document.getElementById("container")!}
             onExpressionUpdate={(expression) => {
@@ -129,6 +133,7 @@ describe("EditExpressionMenu tests", () => {
         <div>
           <div id="container">Popover</div>
           <EditExpressionMenu
+            selectedExpressionName="Expression Name"
             selectedDataType={selectedDataType}
             arrowPlacement={() => document.getElementById("container")!}
             appendTo={() => document.getElementById("container")!}
@@ -144,28 +149,6 @@ describe("EditExpressionMenu tests", () => {
 
     expect(container.querySelector("[id^='pf-select-toggle-id-']")).toBeTruthy();
     expect((container.querySelector("[id^='pf-select-toggle-id-']")! as HTMLInputElement).value).toBe(selectedDataType);
-  });
-
-  test("should render empty expression name, when it is not pre-selected", async () => {
-    const { container } = render(
-      usingTestingBoxedExpressionI18nContext(
-        <div>
-          <div id="container">Popover</div>
-          <EditExpressionMenu
-            arrowPlacement={() => document.getElementById("container")!}
-            appendTo={() => document.getElementById("container")!}
-            onExpressionUpdate={(expression) => {
-              console.log(expression);
-            }}
-          />
-        </div>
-      ).wrapper
-    );
-
-    await activatePopover(container);
-
-    expect(container.querySelector("#expression-name")).toBeTruthy();
-    expect((container.querySelector("#expression-name")! as HTMLInputElement).value).toBe("");
   });
 
   test("should render passed expression name, when it is pre-selected", async () => {
@@ -193,7 +176,7 @@ describe("EditExpressionMenu tests", () => {
   });
 
   test("should trigger the onExpressionUpdate callback when the expression name is changed", async () => {
-    const onExpressionUpdate = (expression: ExpressionProps) => {
+    const onExpressionUpdate = (expression: Expression) => {
       _.identity(expression);
     };
     const mockedOnExpressionUpdate = jest.fn(onExpressionUpdate);
@@ -219,7 +202,7 @@ describe("EditExpressionMenu tests", () => {
 
     expect(mockedOnExpressionUpdate).toHaveBeenCalled();
     expect(mockedOnExpressionUpdate).toHaveBeenCalledWith({
-      expressionName: "changed",
+      name: "changed",
       dataType: DataType.Undefined,
     });
   });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/ExpressionContainer.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/ExpressionContainer.test.tsx
@@ -18,6 +18,7 @@ import { ExpressionContainer } from "../../../components/ExpressionContainer";
 import { render } from "@testing-library/react";
 import * as React from "react";
 import { usingTestingBoxedExpressionI18nContext } from "../test-utils";
+import { LogicType } from "../../../api/LogicType";
 
 describe("ExpressionContainer tests", () => {
   test("should render ExpressionContainer component", () => {
@@ -36,7 +37,7 @@ describe("ExpressionContainer tests", () => {
   });
 
   test("should render expression type, when type prop is passed", () => {
-    const type = "TYPE";
+    const type = LogicType.Context;
     const { container } = render(
       usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test" selectedExpression={type} />).wrapper
     );
@@ -66,7 +67,7 @@ describe("ExpressionContainer tests", () => {
     test("should have the clear action enabled, when logic type is selected", () => {
       const { container } = render(
         usingTestingBoxedExpressionI18nContext(
-          <ExpressionContainer name="Test" selectedExpression="Literal expression" />
+          <ExpressionContainer name="Test" selectedExpression={LogicType.LiteralExpression} />
         ).wrapper
       );
 
@@ -82,7 +83,7 @@ describe("ExpressionContainer tests", () => {
 
   describe("Logic type selection", () => {
     test("should show the pre-selection, when logic type prop is passed", () => {
-      const expressionBoxContent = "Literal expression";
+      const expressionBoxContent = LogicType.LiteralExpression;
       const { container } = render(
         usingTestingBoxedExpressionI18nContext(
           <ExpressionContainer name="Test" selectedExpression={expressionBoxContent} />
@@ -94,7 +95,7 @@ describe("ExpressionContainer tests", () => {
     });
 
     test("should reset the selection, when logic type is selected and clear button gets clicked", () => {
-      const expressionBoxContent = "Literal expression";
+      const expressionBoxContent = LogicType.LiteralExpression;
       const { container } = render(
         usingTestingBoxedExpressionI18nContext(
           <ExpressionContainer name="Test" selectedExpression={expressionBoxContent} />

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/ExpressionContainer.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/ExpressionContainer.test.tsx
@@ -18,11 +18,11 @@ import { ExpressionContainer } from "../../../components/ExpressionContainer";
 import { render } from "@testing-library/react";
 import * as React from "react";
 import { usingTestingBoxedExpressionI18nContext } from "../test-utils";
-import { LogicType } from "../../../api";
+import { DataType, LogicType } from "../../../api";
 
 describe("ExpressionContainer tests", () => {
   test("should render ExpressionContainer component", () => {
-    const expression = { name: "Test" };
+    const expression = { name: "Test", dataType: DataType.Undefined };
 
     const { container } = render(
       usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
@@ -33,7 +33,7 @@ describe("ExpressionContainer tests", () => {
 
   test("should render expression title, when name prop is passed", () => {
     const expressionTitle = "Test";
-    const expression = { name: expressionTitle };
+    const expression = { name: expressionTitle, dataType: DataType.Undefined };
 
     const { container } = render(
       usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
@@ -43,7 +43,7 @@ describe("ExpressionContainer tests", () => {
   });
 
   test("should render expression type, when type prop is passed", () => {
-    const expression = { name: "Test", logicType: LogicType.Context };
+    const expression = { name: "Test", logicType: LogicType.Context, dataType: DataType.Undefined };
     const { container } = render(
       usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
     );
@@ -53,7 +53,7 @@ describe("ExpressionContainer tests", () => {
   });
 
   test("should render expression type as undefined, when type prop is not passed", () => {
-    const expression = { name: "Test" };
+    const expression = { name: "Test", dataType: DataType.Undefined };
 
     const { container } = render(
       usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
@@ -64,7 +64,7 @@ describe("ExpressionContainer tests", () => {
 
   describe("Expression Actions dropdown", () => {
     test("should have the clear action disabled on startup", () => {
-      const expression = { name: "Test" };
+      const expression = { name: "Test", dataType: DataType.Undefined };
 
       const { container } = render(
         usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
@@ -79,7 +79,7 @@ describe("ExpressionContainer tests", () => {
     });
 
     test("should have the clear action enabled, when logic type is selected", () => {
-      const expression = { name: "Test", logicType: LogicType.LiteralExpression };
+      const expression = { name: "Test", logicType: LogicType.LiteralExpression, dataType: DataType.Undefined };
 
       const { container } = render(
         usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
@@ -97,7 +97,7 @@ describe("ExpressionContainer tests", () => {
 
   describe("Logic type selection", () => {
     test("should show the pre-selection, when logic type prop is passed", () => {
-      const expression = { name: "Test", logicType: LogicType.Context };
+      const expression = { name: "Test", logicType: LogicType.Context, dataType: DataType.Undefined };
 
       const { container } = render(
         usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
@@ -108,7 +108,7 @@ describe("ExpressionContainer tests", () => {
     });
 
     test("should reset the selection, when logic type is selected and clear button gets clicked", () => {
-      const expression = { name: "Test", logicType: LogicType.LiteralExpression };
+      const expression = { name: "Test", logicType: LogicType.LiteralExpression, dataType: DataType.Undefined };
 
       const { container } = render(
         usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/ExpressionContainer.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/ExpressionContainer.test.tsx
@@ -38,8 +38,8 @@ describe("ExpressionContainer tests", () => {
     const { container } = render(
       usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
     );
-    expect(container.querySelector("#expression-title")).toBeTruthy();
-    expect(container.querySelector("#expression-title")!.innerHTML).toBe(expressionTitle);
+    expect(container.querySelector(".expression-title")).toBeTruthy();
+    expect(container.querySelector(".expression-title")!.innerHTML).toBe(expressionTitle);
   });
 
   test("should render expression type, when type prop is passed", () => {
@@ -48,8 +48,8 @@ describe("ExpressionContainer tests", () => {
       usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
     );
 
-    expect(container.querySelector("#expression-type")).toBeTruthy();
-    expect(container.querySelector("#expression-type")!.innerHTML).toBe("(" + LogicType.Context + ")");
+    expect(container.querySelector(".expression-type")).toBeTruthy();
+    expect(container.querySelector(".expression-type")!.innerHTML).toBe("(" + LogicType.Context + ")");
   });
 
   test("should render expression type as undefined, when type prop is not passed", () => {
@@ -58,8 +58,8 @@ describe("ExpressionContainer tests", () => {
     const { container } = render(
       usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
     );
-    expect(container.querySelector("#expression-type")).toBeTruthy();
-    expect(container.querySelector("#expression-type")!.innerHTML).toBe("(&lt;Undefined&gt;)");
+    expect(container.querySelector(".expression-type")).toBeTruthy();
+    expect(container.querySelector(".expression-type")!.innerHTML).toBe("(&lt;Undefined&gt;)");
   });
 
   describe("Expression Actions dropdown", () => {
@@ -70,7 +70,7 @@ describe("ExpressionContainer tests", () => {
         usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
       );
 
-      const actionsToggleElement = container.querySelector("#expression-actions-toggle")!;
+      const actionsToggleElement = container.querySelector(".expression-actions-toggle")!;
       const actionsToggleButton = actionsToggleElement as HTMLButtonElement;
       actionsToggleButton.click();
 
@@ -85,7 +85,7 @@ describe("ExpressionContainer tests", () => {
         usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
       );
 
-      const actionsToggleElement = container.querySelector("#expression-actions-toggle")!;
+      const actionsToggleElement = container.querySelector(".expression-actions-toggle")!;
       const actionsToggleButton = actionsToggleElement as HTMLButtonElement;
       actionsToggleButton.click();
 
@@ -103,8 +103,8 @@ describe("ExpressionContainer tests", () => {
         usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
       );
 
-      expect(container.querySelector("#expression-container-box")).toBeTruthy();
-      expect(container.querySelector("#expression-container-box")!.innerHTML).toBe(expression.logicType);
+      expect(container.querySelector(".expression-container-box")).toBeTruthy();
+      expect(container.querySelector(".expression-container-box")!.innerHTML).toBe(expression.logicType);
     });
 
     test("should reset the selection, when logic type is selected and clear button gets clicked", () => {
@@ -114,7 +114,7 @@ describe("ExpressionContainer tests", () => {
         usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
       );
 
-      const actionsToggleElement = container.querySelector("#expression-actions-toggle")!;
+      const actionsToggleElement = container.querySelector(".expression-actions-toggle")!;
       const actionsToggleButton = actionsToggleElement as HTMLButtonElement;
       actionsToggleButton.click();
 
@@ -122,8 +122,8 @@ describe("ExpressionContainer tests", () => {
       const clearAnchor = clearElement as HTMLAnchorElement;
       clearAnchor.click();
 
-      expect(container.querySelector("#expression-container-box")).toBeTruthy();
-      expect(container.querySelector("#expression-container-box")!.innerHTML).not.toBe(expression.logicType);
+      expect(container.querySelector(".expression-container-box")).toBeTruthy();
+      expect(container.querySelector(".expression-container-box")!.innerHTML).not.toBe(expression.logicType);
     });
   });
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/ExpressionContainer.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/ExpressionContainer.test.tsx
@@ -38,7 +38,7 @@ describe("ExpressionContainer tests", () => {
   test("should render expression type, when type prop is passed", () => {
     const type = "TYPE";
     const { container } = render(
-      usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test" type={type} />).wrapper
+      usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test" selectedExpression={type} />).wrapper
     );
 
     expect(container.querySelector("#expression-type")).toBeTruthy();

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/ExpressionContainer.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/ExpressionContainer.test.tsx
@@ -18,12 +18,14 @@ import { ExpressionContainer } from "../../../components/ExpressionContainer";
 import { render } from "@testing-library/react";
 import * as React from "react";
 import { usingTestingBoxedExpressionI18nContext } from "../test-utils";
-import { LogicType } from "../../../api/LogicType";
+import { LogicType } from "../../../api";
 
 describe("ExpressionContainer tests", () => {
   test("should render ExpressionContainer component", () => {
+    const expression = { name: "Test" };
+
     const { container } = render(
-      usingTestingBoxedExpressionI18nContext(<ExpressionContainer decisionName="Test" />).wrapper
+      usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
     );
 
     expect(container).toMatchSnapshot();
@@ -31,8 +33,10 @@ describe("ExpressionContainer tests", () => {
 
   test("should render expression title, when name prop is passed", () => {
     const expressionTitle = "Test";
+    const expression = { name: expressionTitle };
+
     const { container } = render(
-      usingTestingBoxedExpressionI18nContext(<ExpressionContainer decisionName={expressionTitle} />).wrapper
+      usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
     );
     expect(container.querySelector("#expression-title")).toBeTruthy();
     expect(container.querySelector("#expression-title")!.innerHTML).toBe(expressionTitle);
@@ -41,9 +45,7 @@ describe("ExpressionContainer tests", () => {
   test("should render expression type, when type prop is passed", () => {
     const expression = { name: "Test", logicType: LogicType.Context };
     const { container } = render(
-      usingTestingBoxedExpressionI18nContext(
-        <ExpressionContainer decisionName="Test" selectedExpression={expression} />
-      ).wrapper
+      usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
     );
 
     expect(container.querySelector("#expression-type")).toBeTruthy();
@@ -51,8 +53,10 @@ describe("ExpressionContainer tests", () => {
   });
 
   test("should render expression type as undefined, when type prop is not passed", () => {
+    const expression = { name: "Test" };
+
     const { container } = render(
-      usingTestingBoxedExpressionI18nContext(<ExpressionContainer decisionName="Test" />).wrapper
+      usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
     );
     expect(container.querySelector("#expression-type")).toBeTruthy();
     expect(container.querySelector("#expression-type")!.innerHTML).toBe("(&lt;Undefined&gt;)");
@@ -60,8 +64,10 @@ describe("ExpressionContainer tests", () => {
 
   describe("Expression Actions dropdown", () => {
     test("should have the clear action disabled on startup", () => {
+      const expression = { name: "Test" };
+
       const { container } = render(
-        usingTestingBoxedExpressionI18nContext(<ExpressionContainer decisionName="Test" />).wrapper
+        usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
       );
 
       const actionsToggleElement = container.querySelector("#expression-actions-toggle")!;
@@ -76,9 +82,7 @@ describe("ExpressionContainer tests", () => {
       const expression = { name: "Test", logicType: LogicType.LiteralExpression };
 
       const { container } = render(
-        usingTestingBoxedExpressionI18nContext(
-          <ExpressionContainer decisionName="Test" selectedExpression={expression} />
-        ).wrapper
+        usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
       );
 
       const actionsToggleElement = container.querySelector("#expression-actions-toggle")!;
@@ -96,9 +100,7 @@ describe("ExpressionContainer tests", () => {
       const expression = { name: "Test", logicType: LogicType.Context };
 
       const { container } = render(
-        usingTestingBoxedExpressionI18nContext(
-          <ExpressionContainer decisionName="Test" selectedExpression={expression} />
-        ).wrapper
+        usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
       );
 
       expect(container.querySelector("#expression-container-box")).toBeTruthy();
@@ -109,9 +111,7 @@ describe("ExpressionContainer tests", () => {
       const expression = { name: "Test", logicType: LogicType.LiteralExpression };
 
       const { container } = render(
-        usingTestingBoxedExpressionI18nContext(
-          <ExpressionContainer decisionName="Test" selectedExpression={expression} />
-        ).wrapper
+        usingTestingBoxedExpressionI18nContext(<ExpressionContainer selectedExpression={expression} />).wrapper
       );
 
       const actionsToggleElement = container.querySelector("#expression-actions-toggle")!;

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/ExpressionContainer.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/ExpressionContainer.test.tsx
@@ -22,7 +22,9 @@ import { LogicType } from "../../../api/LogicType";
 
 describe("ExpressionContainer tests", () => {
   test("should render ExpressionContainer component", () => {
-    const { container } = render(usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test" />).wrapper);
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(<ExpressionContainer decisionName="Test" />).wrapper
+    );
 
     expect(container).toMatchSnapshot();
   });
@@ -30,31 +32,37 @@ describe("ExpressionContainer tests", () => {
   test("should render expression title, when name prop is passed", () => {
     const expressionTitle = "Test";
     const { container } = render(
-      usingTestingBoxedExpressionI18nContext(<ExpressionContainer name={expressionTitle} />).wrapper
+      usingTestingBoxedExpressionI18nContext(<ExpressionContainer decisionName={expressionTitle} />).wrapper
     );
     expect(container.querySelector("#expression-title")).toBeTruthy();
     expect(container.querySelector("#expression-title")!.innerHTML).toBe(expressionTitle);
   });
 
   test("should render expression type, when type prop is passed", () => {
-    const type = LogicType.Context;
+    const expression = { name: "Test", logicType: LogicType.Context };
     const { container } = render(
-      usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test" selectedExpression={type} />).wrapper
+      usingTestingBoxedExpressionI18nContext(
+        <ExpressionContainer decisionName="Test" selectedExpression={expression} />
+      ).wrapper
     );
 
     expect(container.querySelector("#expression-type")).toBeTruthy();
-    expect(container.querySelector("#expression-type")!.innerHTML).toBe("(" + type + ")");
+    expect(container.querySelector("#expression-type")!.innerHTML).toBe("(" + LogicType.Context + ")");
   });
 
   test("should render expression type as undefined, when type prop is not passed", () => {
-    const { container } = render(usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test" />).wrapper);
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(<ExpressionContainer decisionName="Test" />).wrapper
+    );
     expect(container.querySelector("#expression-type")).toBeTruthy();
     expect(container.querySelector("#expression-type")!.innerHTML).toBe("(&lt;Undefined&gt;)");
   });
 
   describe("Expression Actions dropdown", () => {
     test("should have the clear action disabled on startup", () => {
-      const { container } = render(usingTestingBoxedExpressionI18nContext(<ExpressionContainer name="Test" />).wrapper);
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(<ExpressionContainer decisionName="Test" />).wrapper
+      );
 
       const actionsToggleElement = container.querySelector("#expression-actions-toggle")!;
       const actionsToggleButton = actionsToggleElement as HTMLButtonElement;
@@ -65,9 +73,11 @@ describe("ExpressionContainer tests", () => {
     });
 
     test("should have the clear action enabled, when logic type is selected", () => {
+      const expression = { name: "Test", logicType: LogicType.LiteralExpression };
+
       const { container } = render(
         usingTestingBoxedExpressionI18nContext(
-          <ExpressionContainer name="Test" selectedExpression={LogicType.LiteralExpression} />
+          <ExpressionContainer decisionName="Test" selectedExpression={expression} />
         ).wrapper
       );
 
@@ -83,22 +93,24 @@ describe("ExpressionContainer tests", () => {
 
   describe("Logic type selection", () => {
     test("should show the pre-selection, when logic type prop is passed", () => {
-      const expressionBoxContent = LogicType.LiteralExpression;
+      const expression = { name: "Test", logicType: LogicType.Context };
+
       const { container } = render(
         usingTestingBoxedExpressionI18nContext(
-          <ExpressionContainer name="Test" selectedExpression={expressionBoxContent} />
+          <ExpressionContainer decisionName="Test" selectedExpression={expression} />
         ).wrapper
       );
 
       expect(container.querySelector("#expression-container-box")).toBeTruthy();
-      expect(container.querySelector("#expression-container-box")!.innerHTML).toBe(expressionBoxContent);
+      expect(container.querySelector("#expression-container-box")!.innerHTML).toBe(expression.logicType);
     });
 
     test("should reset the selection, when logic type is selected and clear button gets clicked", () => {
-      const expressionBoxContent = LogicType.LiteralExpression;
+      const expression = { name: "Test", logicType: LogicType.LiteralExpression };
+
       const { container } = render(
         usingTestingBoxedExpressionI18nContext(
-          <ExpressionContainer name="Test" selectedExpression={expressionBoxContent} />
+          <ExpressionContainer decisionName="Test" selectedExpression={expression} />
         ).wrapper
       );
 
@@ -111,7 +123,7 @@ describe("ExpressionContainer tests", () => {
       clearAnchor.click();
 
       expect(container.querySelector("#expression-container-box")).toBeTruthy();
-      expect(container.querySelector("#expression-container-box")!.innerHTML).not.toBe(expressionBoxContent);
+      expect(container.querySelector("#expression-container-box")!.innerHTML).not.toBe(expression.logicType);
     });
   });
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/__snapshots__/ExpressionContainer.test.tsx.snap
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/__snapshots__/ExpressionContainer.test.tsx.snap
@@ -6,19 +6,19 @@ exports[`ExpressionContainer tests should render ExpressionContainer component 1
     class="expression-container"
   >
     <span
-      id="expression-title"
+      class="expression-title"
     >
       Test
     </span>
     <span
-      id="expression-type"
+      class="expression-type"
     >
       (
       &lt;Undefined&gt;
       )
     </span>
     <span
-      id="expression-actions"
+      class="expression-actions"
     >
       <div
         class="pf-c-dropdown"
@@ -30,8 +30,8 @@ exports[`ExpressionContainer tests should render ExpressionContainer component 1
           aria-expanded="false"
           aria-haspopup="true"
           aria-label="Actions"
-          class="pf-c-dropdown__toggle pf-m-plain"
-          id="expression-actions-toggle"
+          class="pf-c-dropdown__toggle pf-m-plain expression-actions-toggle"
+          id="pf-dropdown-toggle-id-0"
           type="button"
         >
           <svg
@@ -51,8 +51,7 @@ exports[`ExpressionContainer tests should render ExpressionContainer component 1
       </div>
     </span>
     <div
-      class="logic-type-not-present"
-      id="expression-container-box"
+      class="expression-container-box logic-type-not-present"
     >
       Select expression
     </div>

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/LiteralExpression/LiteralExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/LiteralExpression/LiteralExpression.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from "@testing-library/react";
+import { usingTestingBoxedExpressionI18nContext } from "../test-utils";
+import * as React from "react";
+import { LiteralExpression } from "../../../components/LiteralExpression";
+import { DataType, LogicType } from "../../../api";
+import { act } from "react-dom/test-utils";
+
+jest.useFakeTimers();
+const flushPromises = () => new Promise((resolve) => process.nextTick(resolve));
+
+describe("LiteralExpression tests", () => {
+  describe("LiteralExpression Header", () => {
+    test("should render expression's name, when name property is passed", () => {
+      const expressionName = "expression name";
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <LiteralExpression
+            logicType={LogicType.LiteralExpression}
+            name={expressionName}
+            dataType={DataType.Undefined}
+          />
+        ).wrapper
+      );
+      expect(container.querySelector(".expression-name")).toBeTruthy();
+      expect(container.querySelector(".expression-name")!.innerHTML).toBe(expressionName);
+    });
+
+    test("should render expression's data type, when dataType property is passed", () => {
+      const dataType = DataType.Boolean;
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <LiteralExpression logicType={LogicType.LiteralExpression} name={"expressionName"} dataType={dataType} />
+        ).wrapper
+      );
+      expect(container.querySelector(".expression-data-type")).toBeTruthy();
+      expect(container.querySelector(".expression-data-type")!.innerHTML).toBe("(" + dataType + ")");
+    });
+
+    test("should render edit expression menu, when header is clicked", async () => {
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <LiteralExpression
+            logicType={LogicType.LiteralExpression}
+            name={"expressionName"}
+            dataType={DataType.Boolean}
+          />
+        ).wrapper
+      );
+
+      await act(async () => {
+        const literalExpressionHeader = container.querySelector(".literal-expression-header")! as HTMLElement;
+        literalExpressionHeader.click();
+        await flushPromises();
+        jest.runAllTimers();
+      });
+
+      expect(document.querySelector(".selector-menu-title")).toBeTruthy();
+    });
+  });
+
+  describe("LiteralExpression Body", () => {
+    test("should render expression's content, when content property is passed", () => {
+      const content = "content";
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <LiteralExpression
+            logicType={LogicType.LiteralExpression}
+            name={"expressionName"}
+            dataType={DataType.Boolean}
+            content={content}
+          />
+        ).wrapper
+      );
+
+      expect(container.querySelector(".literal-expression-body textarea")).toBeTruthy();
+      expect(container.querySelector(".literal-expression-body textarea")!.innerHTML).toBe(content);
+    });
+
+    test("should render nothing, when content property is not passed", () => {
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <LiteralExpression
+            logicType={LogicType.LiteralExpression}
+            name={"expressionName"}
+            dataType={DataType.Boolean}
+          />
+        ).wrapper
+      );
+
+      expect(container.querySelector(".literal-expression-body textarea")).toBeTruthy();
+      expect(container.querySelector(".literal-expression-body textarea")!.innerHTML).toBe("");
+    });
+  });
+});

--- a/kie-wb-common-react/boxed-expression-editor/src/api/Expression.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/Expression.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-export interface ExpressionProps {
-  expressionName?: string;
-  dataType: string;
+import { LogicType } from "./LogicType";
+import { DataType } from "./DataType";
+
+export interface Expression {
+  name: string;
+  dataType?: DataType;
+  logicType?: LogicType;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -20,10 +20,10 @@ import { DataType } from "./DataType";
 export interface ExpressionProps {
   /** Expression name (which, in DMN world, is equal to the Decision node's name) */
   name: string;
+  /** Expression data type */
+  dataType: DataType;
   /** Optional callback executed to update expression's name and data type */
   updateNameAndDataTypeCallback?: (updatedName: string, updatedDataType: DataType) => void;
-  /** Optional data type */
-  dataType?: DataType;
   /** Logic type should not be defined at this stage */
   logicType?: LogicType;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -18,11 +18,19 @@ import { LogicType } from "./LogicType";
 import { DataType } from "./DataType";
 
 export interface ExpressionProps {
+  /** Expression name (which, in DMN world, is equal to the Decision node's name) */
   name: string;
+  /** Optional callback executed to update expression's name and data type */
+  updateNameAndDataTypeCallback?: (updatedName: string, updatedDataType: DataType) => void;
+  /** Optional data type */
   dataType?: DataType;
+  /** Logic type should not be defined at this stage */
   logicType?: LogicType;
 }
 
 export interface LiteralExpressionProps extends ExpressionProps {
+  /** Logic type must be LiteralExpression */
+  logicType: LogicType.LiteralExpression;
+  /** Optional content to display for this literal expression */
   content?: string;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -17,8 +17,12 @@
 import { LogicType } from "./LogicType";
 import { DataType } from "./DataType";
 
-export interface Expression {
+export interface ExpressionProps {
   name: string;
   dataType?: DataType;
   logicType?: LogicType;
+}
+
+export interface LiteralExpressionProps extends ExpressionProps {
+  content?: string;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/api/LogicType.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/LogicType.ts
@@ -15,6 +15,7 @@
  */
 
 export enum LogicType {
+  Undefined = "<Undefined>",
   LiteralExpression = "Literal expression",
   Context = "Context",
   DecisionTable = "Decision Table",

--- a/kie-wb-common-react/boxed-expression-editor/src/api/LogicType.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/LogicType.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export enum LogicType {
+  LiteralExpression = "Literal expression",
+  Context = "Context",
+  DecisionTable = "Decision Table",
+  Relation = "Relation",
+  Function = "Function",
+  Invocation = "Invocation",
+  List = "List",
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/api/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/index.ts
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
-export * from "./Expression";
+export * from "./ExpressionProps";
 export * from "./DataType";
+export * from "./LogicType";

--- a/kie-wb-common-react/boxed-expression-editor/src/api/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from "./ExpressionProps";
+export * from "./Expression";
 export * from "./DataType";

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import { useCallback, useState } from "react";
 import { PopoverMenu } from "../PopoverMenu";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
-import { DataType, ExpressionProps } from "../../api";
+import { DataType, Expression } from "../../api";
 import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";
 import * as _ from "lodash";
 
@@ -37,9 +37,9 @@ export interface EditExpressionMenuProps {
   /** The pre-selected data type */
   selectedDataType?: DataType;
   /** The pre-selected expression name */
-  selectedExpressionName?: string;
+  selectedExpressionName: string;
   /** Function to be called when the expression gets updated, passing the most updated version of it */
-  onExpressionUpdate: (expression: ExpressionProps) => void;
+  onExpressionUpdate: (expression: Expression) => void;
 }
 
 export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps> = ({
@@ -66,7 +66,7 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
       setExpressionName(event.target.value);
       if (event.type === "blur") {
         onExpressionUpdate({
-          expressionName: event.target.value,
+          name: event.target.value,
           dataType: chosenDataType,
         });
       }
@@ -79,7 +79,7 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
       setDataTypeSelectOpen(false);
       setDataType(selection);
       onExpressionUpdate({
-        expressionName: chosenExpressionName,
+        name: chosenExpressionName,
         dataType: selection,
       });
     },

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import { useCallback, useState } from "react";
 import { PopoverMenu } from "../PopoverMenu";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
-import { DataType, Expression } from "../../api";
+import { DataType, ExpressionProps } from "../../api";
 import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";
 import * as _ from "lodash";
 
@@ -39,7 +39,7 @@ export interface EditExpressionMenuProps {
   /** The pre-selected expression name */
   selectedExpressionName: string;
   /** Function to be called when the expression gets updated, passing the most updated version of it */
-  onExpressionUpdate: (expression: Expression) => void;
+  onExpressionUpdate: (expression: ExpressionProps) => void;
 }
 
 export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps> = ({

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
@@ -15,8 +15,8 @@
  */
 
 .expression-container #expression-container-box {
-  width: 170px;
-  height: 50px;
+  min-width: 170px;
+  min-height: 50px;
   border-style: ridge;
   border-color: #39A5DC;
   display: flex;
@@ -26,14 +26,17 @@
   display: -moz-box;
   display: -ms-flexbox;
   display: -webkit-flex;
+}
+
+.expression-container > #expression-container-box.logic-type-not-present {
   cursor: pointer;
 }
 
-.expression-container #expression-container-box.logic-type-selected {
-  pointer-events: none;
+.expression-container > #expression-container-box.logic-type-selected {
+  cursor: default;
 }
 
-.expression-container #expression-container-box,
+.expression-container > #expression-container-box,
 .expression-container #expression-type {
   font-size: smaller;
   font-style: italic;

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-.expression-container #expression-container-box {
+.expression-container .expression-container-box {
   min-width: 170px;
   min-height: 50px;
   border-style: ridge;
@@ -28,30 +28,30 @@
   display: -webkit-flex;
 }
 
-.expression-container > #expression-container-box.logic-type-not-present {
+.expression-container > .expression-container-box.logic-type-not-present {
   cursor: pointer;
 }
 
-.expression-container > #expression-container-box.logic-type-selected {
+.expression-container > .expression-container-box.logic-type-selected {
   cursor: default;
 }
 
-.expression-container > #expression-container-box,
-.expression-container #expression-type {
+.expression-container > .expression-container-box,
+.expression-container .expression-type {
   font-size: smaller;
   font-style: italic;
   color: gray;
 }
 
-#expression-actions .pf-c-dropdown .pf-c-dropdown__menu,
-#expression-actions-toggle {
+.expression-actions .pf-c-dropdown .pf-c-dropdown__menu,
+.expression-actions-toggle {
   padding: 0;
 }
 
-#expression-actions .pf-c-dropdown a {
+.expression-actions .pf-c-dropdown a {
   font-size: var(--small-font-size);
 }
 
-.expression-container #expression-actions .pf-c-dropdown button:focus {
+.expression-container .expression-actions .pf-c-dropdown button:focus {
   outline-width: 0;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -62,7 +62,8 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
   const executeClearAction = useCallback(() => {
     setLogicTypeSelected(false);
     setSelectedExpression({
-      ...selectedExpression,
+      name: selectedExpression.name,
+      dataType: selectedExpression.dataType,
       logicType: LogicType.Undefined,
     });
   }, [selectedExpression]);
@@ -101,20 +102,36 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
     );
   }, [i18n.selectLogicType, onLogicTypeSelect, renderLogicTypeItems]);
 
-  const renderSelectedExpression = useCallback((selectedExpression: ExpressionProps) => {
-    switch (selectedExpression.logicType) {
-      case LogicType.LiteralExpression:
-        return <LiteralExpression {...(selectedExpression as LiteralExpressionProps)} />;
-      case LogicType.Context:
-      case LogicType.DecisionTable:
-      case LogicType.Relation:
-      case LogicType.Function:
-      case LogicType.Invocation:
-      case LogicType.List:
-      default:
-        return selectedExpression.logicType;
-    }
-  }, []);
+  const updateNameAndDataType = useCallback(
+    (updatedName, updatedDataType) => {
+      setSelectedExpression({
+        ...selectedExpression,
+        name: updatedName,
+        dataType: updatedDataType,
+      });
+    },
+    [selectedExpression]
+  );
+
+  const renderSelectedExpression = useCallback(
+    (selectedExpression: ExpressionProps) => {
+      selectedExpression.updateNameAndDataTypeCallback = updateNameAndDataType;
+
+      switch (selectedExpression.logicType) {
+        case LogicType.LiteralExpression:
+          return <LiteralExpression {...(selectedExpression as LiteralExpressionProps)} />;
+        case LogicType.Context:
+        case LogicType.DecisionTable:
+        case LogicType.Relation:
+        case LogicType.Function:
+        case LogicType.Invocation:
+        case LogicType.List:
+        default:
+          return selectedExpression.logicType;
+      }
+    },
+    [updateNameAndDataType]
+  );
 
   return (
     <div className="expression-container">

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -72,7 +72,9 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
     return (
       <Dropdown
         onSelect={() => setActionDropDownOpen(!actionDropdownIsOpen)}
-        toggle={<KebabToggle onToggle={(isOpen) => setActionDropDownOpen(isOpen)} id="expression-actions-toggle" />}
+        toggle={
+          <KebabToggle onToggle={(isOpen) => setActionDropDownOpen(isOpen)} className="expression-actions-toggle" />
+        }
         isOpen={actionDropdownIsOpen}
         isPlain
         dropdownItems={[
@@ -96,7 +98,7 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
     return (
       <PopoverMenu
         title={i18n.selectLogicType}
-        arrowPlacement={() => document.getElementById("expression-container-box")!}
+        arrowPlacement={() => document.querySelector(".expression-container-box")! as HTMLElement}
         body={<SimpleList onSelect={onLogicTypeSelect}>{renderLogicTypeItems()}</SimpleList>}
       />
     );
@@ -135,13 +137,12 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
 
   return (
     <div className="expression-container">
-      <span id="expression-title">{selectedExpression.name}</span>
-      <span id="expression-type">({selectedExpression.logicType || LogicType.Undefined})</span>
-      <span id="expression-actions">{renderExpressionActionsDropdown()}</span>
+      <span className="expression-title">{selectedExpression.name}</span>
+      <span className="expression-type">({selectedExpression.logicType || LogicType.Undefined})</span>
+      <span className="expression-actions">{renderExpressionActionsDropdown()}</span>
 
       <div
-        id="expression-container-box"
-        className={logicTypeIsPresent ? "logic-type-selected" : "logic-type-not-present"}
+        className={`expression-container-box ${logicTypeIsPresent ? "logic-type-selected" : "logic-type-not-present"}`}
       >
         {selectedExpression.logicType ? renderSelectedExpression(selectedExpression) : i18n.selectExpression}
       </div>

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -86,13 +86,17 @@ export const ExpressionContainer: ({ name, selectedExpression }: ExpressionConta
   };
 
   const renderLogicTypeItems = () => {
-    return _.map(Object.values(LogicType), (key) => <SimpleListItem key={key}>{key}</SimpleListItem>);
+    return _.map(getLogicTypesWithoutUndefined(), (key) => <SimpleListItem key={key}>{key}</SimpleListItem>);
+  };
+
+  const getLogicTypesWithoutUndefined = () => {
+    return Object.values(LogicType).filter((logicType) => logicType != LogicType.Undefined);
   };
 
   return (
     <div className="expression-container">
       <span id="expression-title">{props.name || ""}</span>
-      <span id="expression-type">({selectedExpression || "<Undefined>"})</span>
+      <span id="expression-type">({selectedExpression || LogicType.Undefined})</span>
       <span id="expression-actions">{renderExpressionActionsDropdown()}</span>
 
       <div

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -59,7 +59,7 @@ export const ExpressionContainer: ({ name, selectedExpression }: ExpressionConta
     setSelectedExpression(undefined);
   }, []);
 
-  const renderExpressionActionsDropdown = () => {
+  const renderExpressionActionsDropdown = useCallback(() => {
     return (
       <Dropdown
         onSelect={() => setActionDropDownOpen(!actionDropdownIsOpen)}
@@ -73,9 +73,17 @@ export const ExpressionContainer: ({ name, selectedExpression }: ExpressionConta
         ]}
       />
     );
-  };
+  }, [i18n.clear, actionDropdownIsOpen, logicTypeIsPresent, executeClearAction]);
 
-  const buildLogicSelectorMenu = () => {
+  const getLogicTypesWithoutUndefined = useCallback(() => {
+    return Object.values(LogicType).filter((logicType) => logicType !== LogicType.Undefined);
+  }, []);
+
+  const renderLogicTypeItems = useCallback(() => {
+    return _.map(getLogicTypesWithoutUndefined(), (key) => <SimpleListItem key={key}>{key}</SimpleListItem>);
+  }, [getLogicTypesWithoutUndefined]);
+
+  const buildLogicSelectorMenu = useCallback(() => {
     return (
       <PopoverMenu
         title={i18n.selectLogicType}
@@ -83,15 +91,7 @@ export const ExpressionContainer: ({ name, selectedExpression }: ExpressionConta
         body={<SimpleList onSelect={onLogicTypeSelect}>{renderLogicTypeItems()}</SimpleList>}
       />
     );
-  };
-
-  const renderLogicTypeItems = () => {
-    return _.map(getLogicTypesWithoutUndefined(), (key) => <SimpleListItem key={key}>{key}</SimpleListItem>);
-  };
-
-  const getLogicTypesWithoutUndefined = () => {
-    return Object.values(LogicType).filter((logicType) => logicType != LogicType.Undefined);
-  };
+  }, [i18n.selectLogicType, onLogicTypeSelect, renderLogicTypeItems]);
 
   return (
     <div className="expression-container">

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -28,12 +28,13 @@ import {
   SimpleListItemProps,
 } from "@patternfly/react-core";
 import { PopoverMenu } from "../PopoverMenu";
+import { LogicType } from "../../api/LogicType";
 
 export interface ExpressionContainerProps {
   /** The name of the expression */
   name: string;
   /** Selected expression is already present */
-  selectedExpression?: string;
+  selectedExpression?: LogicType;
 }
 
 export const ExpressionContainer: ({ name, selectedExpression }: ExpressionContainerProps) => JSX.Element = (
@@ -48,14 +49,14 @@ export const ExpressionContainer: ({ name, selectedExpression }: ExpressionConta
   const onLogicTypeSelect = useCallback(
     (currentItem: React.RefObject<HTMLButtonElement>, currentItemProps: SimpleListItemProps) => {
       setLogicTypeSelected(true);
-      setSelectedExpression(currentItemProps.children as string);
+      setSelectedExpression(currentItemProps.children as LogicType);
     },
     []
   );
 
   const executeClearAction = useCallback(() => {
     setLogicTypeSelected(false);
-    setSelectedExpression("");
+    setSelectedExpression(undefined);
   }, []);
 
   const renderExpressionActionsDropdown = () => {
@@ -85,18 +86,7 @@ export const ExpressionContainer: ({ name, selectedExpression }: ExpressionConta
   };
 
   const renderLogicTypeItems = () => {
-    return _.map(
-      [
-        i18n.literalExpression,
-        i18n.context,
-        i18n.decisionTable,
-        i18n.relation,
-        i18n.function,
-        i18n.invocation,
-        i18n.list,
-      ],
-      (key) => <SimpleListItem key={key}>{key}</SimpleListItem>
-    );
+    return _.map(Object.values(LogicType), (key) => <SimpleListItem key={key}>{key}</SimpleListItem>);
   };
 
   return (

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -32,20 +32,18 @@ import { PopoverMenu } from "../PopoverMenu";
 export interface ExpressionContainerProps {
   /** The name of the expression */
   name: string;
-  /** The type of the expression */
-  type?: string;
   /** Selected expression is already present */
   selectedExpression?: string;
 }
 
-export const ExpressionContainer: (props: ExpressionContainerProps) => JSX.Element = (
+export const ExpressionContainer: ({ name, selectedExpression }: ExpressionContainerProps) => JSX.Element = (
   props: ExpressionContainerProps
 ) => {
   const { i18n } = useBoxedExpressionEditorI18n();
 
   const [logicTypeIsPresent, setLogicTypeSelected] = useState(!_.isEmpty(props.selectedExpression));
   const [actionDropdownIsOpen, setActionDropDownOpen] = useState(false);
-  const [selectedExpression, setSelectedExpression] = useState(props.selectedExpression || i18n.selectExpression);
+  const [selectedExpression, setSelectedExpression] = useState(props.selectedExpression);
 
   const onLogicTypeSelect = useCallback(
     (currentItem: React.RefObject<HTMLButtonElement>, currentItemProps: SimpleListItemProps) => {
@@ -57,8 +55,8 @@ export const ExpressionContainer: (props: ExpressionContainerProps) => JSX.Eleme
 
   const executeClearAction = useCallback(() => {
     setLogicTypeSelected(false);
-    setSelectedExpression(i18n.selectExpression);
-  }, [i18n.selectExpression]);
+    setSelectedExpression("");
+  }, []);
 
   const renderExpressionActionsDropdown = () => {
     return (
@@ -104,14 +102,14 @@ export const ExpressionContainer: (props: ExpressionContainerProps) => JSX.Eleme
   return (
     <div className="expression-container">
       <span id="expression-title">{props.name || ""}</span>
-      <span id="expression-type">({props.type ?? "<Undefined>"})</span>
+      <span id="expression-type">({selectedExpression || "<Undefined>"})</span>
       <span id="expression-actions">{renderExpressionActionsDropdown()}</span>
 
       <div
         id="expression-container-box"
         className={logicTypeIsPresent ? "logic-type-selected" : "logic-type-not-present"}
       >
-        {selectedExpression}
+        {selectedExpression || i18n.selectExpression}
       </div>
 
       {!logicTypeIsPresent ? buildLogicSelectorMenu() : null}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.literal-expression {
+  width: 300px;
+  margin: 10px;
+}
+
+.literal-expression .literal-expression-header {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 5px;
+  border-style: ridge;
+  background-color: #DEF3FF;
+  color: black;
+  cursor: pointer;
+}
+
+.literal-expression .literal-expression-header:active {
+  border: 2px solid black;
+}
+
+.literal-expression .literal-expression-header .expression-data-type {
+   font-style: normal;
+}
+
+.literal-expression .literal-expression-body {
+
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
@@ -46,6 +46,11 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
     setLiteralExpressionContent(updatedContent);
   }, []);
 
+  const getEditExpressionMenuArrowPlacement = useCallback(
+    () => document.querySelector(".literal-expression-header")! as HTMLElement,
+    []
+  );
+
   return (
     <div className="literal-expression">
       <div className="literal-expression-header">
@@ -60,7 +65,7 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
         />
       </div>
       <EditExpressionMenu
-        arrowPlacement={() => document.querySelector(".literal-expression-header")! as HTMLElement}
+        arrowPlacement={getEditExpressionMenuArrowPlacement}
         selectedExpressionName={expressionName}
         selectedDataType={expressionDataType}
         onExpressionUpdate={onExpressionUpdate}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
@@ -14,15 +14,57 @@
  * limitations under the License.
  */
 
+import "./LiteralExpression.css";
 import * as React from "react";
-import { LiteralExpressionProps } from "../../api";
+import { useCallback, useState } from "react";
+import { ExpressionProps, LiteralExpressionProps } from "../../api";
+import { TextArea } from "@patternfly/react-core";
+import { EditExpressionMenu } from "../EditExpressionMenu";
 
 export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> = ({
   content,
   dataType,
-  logicType,
   name,
+  updateNameAndDataTypeCallback,
 }: LiteralExpressionProps) => {
-  console.log("content", content);
-  return <div>Literal Expression</div>;
+  const [expressionName, setExpressionName] = useState(name);
+  const [expressionDataType, setExpressionDataType] = useState(dataType);
+  const [literalExpressionContent, setLiteralExpressionContent] = useState(content);
+
+  const onExpressionUpdate = useCallback(
+    ({ dataType, name }: ExpressionProps) => {
+      setExpressionName(name);
+      setExpressionDataType(dataType);
+      if (updateNameAndDataTypeCallback && dataType) {
+        updateNameAndDataTypeCallback(name, dataType);
+      }
+    },
+    [updateNameAndDataTypeCallback]
+  );
+
+  const onContentChange = useCallback((updatedContent) => {
+    setLiteralExpressionContent(updatedContent);
+  }, []);
+
+  return (
+    <div className="literal-expression">
+      <div className="literal-expression-header">
+        <p className="expression-name">{expressionName}</p>
+        <p className="expression-data-type">({expressionDataType})</p>
+      </div>
+      <div className="literal-expression-body">
+        <TextArea
+          defaultValue={literalExpressionContent}
+          onChange={onContentChange}
+          aria-label="literal-expression-content"
+        />
+      </div>
+      <EditExpressionMenu
+        arrowPlacement={() => document.querySelector(".literal-expression-header")! as HTMLElement}
+        selectedExpressionName={expressionName}
+        selectedDataType={expressionDataType}
+        onExpressionUpdate={onExpressionUpdate}
+      />
+    </div>
+  );
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
@@ -15,12 +15,14 @@
  */
 
 import * as React from "react";
+import { LiteralExpressionProps } from "../../api";
 
-export interface LiteralExpressionProps {
-  /** Title of the popover menu */
-  title?: string;
-}
-
-export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> = () => {
+export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> = ({
+  content,
+  dataType,
+  logicType,
+  name,
+}: LiteralExpressionProps) => {
+  console.log("content", content);
   return <div>Literal Expression</div>;
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+export interface LiteralExpressionProps {
+  /** Title of the popover menu */
+  title?: string;
+}
+
+export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> = () => {
+  return <div>Literal Expression</div>;
+};

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./LiteralExpression";

--- a/kie-wb-common-react/boxed-expression-editor/src/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/index.ts
@@ -15,3 +15,4 @@
  */
 
 export * from "./components";
+export * from "./api";


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/KOGITO-3631

_Context:_
This is the first, simple expression type. 
Monaco editor is not yet present. It will be included with [KOGITO-3655](https://issues.redhat.com/browse/KOGITO-3655)

_Where we want to go:_
The short term goal is to include the React boxed expression editor version inside the GWT editor, for editing only the Literal Expression.

_Disclaimer:_
In the next task, we are going to create an hook with the external world. The boxed expression editor will accept a function to be called in order to retrieve the current expression value. In that way, the GWT editor will be able to receive the most updated version of the expression and eventually to save it. 
The showcase application will be modified in order to continuously display the JSON related to the expression.

_In action:_
![KOGITO-3631](https://user-images.githubusercontent.com/22591802/100606435-b8052800-3309-11eb-855f-c7241dc0470d.gif)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
