### PR TITLE
KOGITO-3952: Expression components should be able to spread their current definition programmatically

### DIFF
--- a/kie-wb-common-react/boxed-expression-editor/showcase/src/index.css
+++ b/kie-wb-common-react/boxed-expression-editor/showcase/src/index.css
@@ -24,3 +24,14 @@ body {
   display: -ms-flexbox;
   display: -webkit-flex;
 }
+
+.showcase {
+  display: flex;
+  justify-content: space-between;
+}
+
+.showcase .updated-json {
+  margin-left: 5em;
+  border-style: inset;
+  padding: 1em;
+}

--- a/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
@@ -15,14 +15,45 @@
  */
 
 import * as React from "react";
+import { useState } from "react";
 import * as ReactDOM from "react-dom";
 import './index.css';
-import { BoxedExpressionEditor, DataType, ExpressionContainerProps } from "./boxed_expression_editor";
+import {
+  BoxedExpressionEditor,
+  DataType,
+  ExpressionContainerProps,
+  ExpressionProps,
+  LiteralExpressionProps
+} from "./boxed_expression_editor";
 
-const selectedExpression = {
-  'name': 'Expression Name',
-  'dataType': DataType.Undefined,
+export const App: React.FunctionComponent = () => {
+  //This definition comes directly from the decision node
+  const selectedExpression = {
+    'name': 'Expression Name',
+    'dataType': DataType.Undefined,
+  };
+
+  const [updatedExpression, setExpression] = useState(selectedExpression);
+
+  const expressionDefinition: ExpressionContainerProps = { 'selectedExpression': selectedExpression };
+
+  //Defining global function that will be available in the Window namespace and used by the BoxedExpressionEditor component
+  window.beeApi = {
+    resetExpressionDefinition : (definition: ExpressionProps) => setExpression(definition),
+    broadcastLiteralExpressionDefinition : (definition: LiteralExpressionProps) => setExpression(definition)
+  };
+
+  return (
+    <div className="showcase">
+      <div className="boxed-expression">
+        <BoxedExpressionEditor expressionDefinition={expressionDefinition} />
+      </div>
+      <div className="updated-json">
+        <p>⚠ Currently, JSON gets updated only for literal expression logic type</p>
+        <pre>{JSON.stringify(updatedExpression, null, 2)}</pre>
+      </div>
+    </div>
+  );
 };
-const expressionDefinition: ExpressionContainerProps = {'selectedExpression': selectedExpression};
 
-ReactDOM.render(<BoxedExpressionEditor expressionDefinition={expressionDefinition}/>, document.getElementById('root'));
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 import { useState } from "react";
 import * as ReactDOM from "react-dom";
-import './index.css';
+import "./index.css";
 import {
   BoxedExpressionEditor,
   DataType,
@@ -29,13 +29,13 @@ import {
 export const App: React.FunctionComponent = () => {
   //This definition comes directly from the decision node
   const selectedExpression = {
-    name: 'Expression Name',
+    name: "Expression Name",
     dataType: DataType.Undefined,
   };
 
   const [updatedExpression, setUpdatedExpression] = useState(selectedExpression);
 
-  const expressionDefinition: ExpressionContainerProps = { 'selectedExpression': selectedExpression };
+  const expressionDefinition: ExpressionContainerProps = { selectedExpression };
 
   //Defining global function that will be available in the Window namespace and used by the BoxedExpressionEditor component
   window.beeApi = {
@@ -56,4 +56,4 @@ export const App: React.FunctionComponent = () => {
   );
 };
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
@@ -29,18 +29,18 @@ import {
 export const App: React.FunctionComponent = () => {
   //This definition comes directly from the decision node
   const selectedExpression = {
-    'name': 'Expression Name',
-    'dataType': DataType.Undefined,
+    name: 'Expression Name',
+    dataType: DataType.Undefined,
   };
 
-  const [updatedExpression, setExpression] = useState(selectedExpression);
+  const [updatedExpression, setUpdatedExpression] = useState(selectedExpression);
 
   const expressionDefinition: ExpressionContainerProps = { 'selectedExpression': selectedExpression };
 
   //Defining global function that will be available in the Window namespace and used by the BoxedExpressionEditor component
   window.beeApi = {
-    resetExpressionDefinition : (definition: ExpressionProps) => setExpression(definition),
-    broadcastLiteralExpressionDefinition : (definition: LiteralExpressionProps) => setExpression(definition)
+    resetExpressionDefinition : (definition: ExpressionProps) => setUpdatedExpression(definition),
+    broadcastLiteralExpressionDefinition : (definition: LiteralExpressionProps) => setUpdatedExpression(definition)
   };
 
   return (

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/__snapshots__/BoxedExpressionEditor.test.tsx.snap
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/__snapshots__/BoxedExpressionEditor.test.tsx.snap
@@ -17,39 +17,6 @@ exports[`BoxedExpressionEditor tests should render BoxedExpressionEditor compone
       &lt;Undefined&gt;
       )
     </span>
-    <span
-      class="expression-actions"
-    >
-      <div
-        class="pf-c-dropdown"
-        data-ouia-component-id="OUIA-Generated-Dropdown-1"
-        data-ouia-component-type="PF4/Dropdown"
-        data-ouia-safe="true"
-      >
-        <button
-          aria-expanded="false"
-          aria-haspopup="true"
-          aria-label="Actions"
-          class="pf-c-dropdown__toggle pf-m-plain expression-actions-toggle"
-          id="pf-dropdown-toggle-id-0"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 192 512"
-            width="1em"
-          >
-            <path
-              d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-            />
-          </svg>
-        </button>
-      </div>
-    </span>
     <div
       class="expression-container-box logic-type-not-present"
     >

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/__snapshots__/ExpressionContainer.test.tsx.snap
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/__snapshots__/ExpressionContainer.test.tsx.snap
@@ -17,39 +17,6 @@ exports[`ExpressionContainer tests should render ExpressionContainer component 1
       &lt;Undefined&gt;
       )
     </span>
-    <span
-      class="expression-actions"
-    >
-      <div
-        class="pf-c-dropdown"
-        data-ouia-component-id="OUIA-Generated-Dropdown-1"
-        data-ouia-component-type="PF4/Dropdown"
-        data-ouia-safe="true"
-      >
-        <button
-          aria-expanded="false"
-          aria-haspopup="true"
-          aria-label="Actions"
-          class="pf-c-dropdown__toggle pf-m-plain expression-actions-toggle"
-          id="pf-dropdown-toggle-id-0"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 192 512"
-            width="1em"
-          >
-            <path
-              d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-            />
-          </svg>
-        </button>
-      </div>
-    </span>
     <div
       class="expression-container-box logic-type-not-present"
     >

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/LiteralExpression/LiteralExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/LiteralExpression/LiteralExpression.test.tsx
@@ -52,6 +52,33 @@ describe("LiteralExpression tests", () => {
       expect(container.querySelector(".expression-data-type")!.innerHTML).toBe("(" + dataType + ")");
     });
 
+    test("should render no header section, when isHeadless property is passed", () => {
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <LiteralExpression
+            isHeadless={true}
+            logicType={LogicType.LiteralExpression}
+            name={"expressionName"}
+            dataType={DataType.Undefined}
+          />
+        ).wrapper
+      );
+      expect(container.querySelector(".literal-expression-header")).toBeFalsy();
+    });
+
+    test("should render header section, when isHeadless property is not passed or it is false", () => {
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <LiteralExpression
+            logicType={LogicType.LiteralExpression}
+            name={"expressionName"}
+            dataType={DataType.Undefined}
+          />
+        ).wrapper
+      );
+      expect(container.querySelector(".literal-expression-header")).toBeTruthy();
+    });
+
     test("should render edit expression menu, when header is clicked", async () => {
       const { container } = render(
         usingTestingBoxedExpressionI18nContext(

--- a/kie-wb-common-react/boxed-expression-editor/src/api/BoxedExpressionEditor.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/BoxedExpressionEditor.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ExpressionProps, LiteralExpressionProps } from "./ExpressionProps";
+
+export {};
+
+declare global {
+  //API that BoxedExpressionEditor (bee) is expecting to be defined in the Window namespace
+  interface Window {
+    beeApi: {
+      resetExpressionDefinition: (definition: ExpressionProps) => void;
+      broadcastLiteralExpressionDefinition: (definition: LiteralExpressionProps) => void;
+    };
+  }
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -23,7 +23,7 @@ export interface ExpressionProps {
   /** Expression data type */
   dataType: DataType;
   /** Optional callback executed to update expression's name and data type */
-  updateNameAndDataTypeCallback?: (updatedName: string, updatedDataType: DataType) => void;
+  onUpdatingNameAndDataType?: (updatedName: string, updatedDataType: DataType) => void;
   /** Logic type should not be defined at this stage */
   logicType?: LogicType;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -33,4 +33,6 @@ export interface LiteralExpressionProps extends ExpressionProps {
   logicType: LogicType.LiteralExpression;
   /** Optional content to display for this literal expression */
   content?: string;
+  /** True to have no header for this specific literal expression */
+  isHeadless?: boolean;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
@@ -57,9 +57,9 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
   nameField = nameField ?? i18n.name;
   dataTypeField = dataTypeField ?? i18n.dataType;
 
-  const [dataTypeSelectIsOpen, setDataTypeSelectOpen] = useState(false);
-  const [chosenDataType, setDataType] = useState(selectedDataType);
-  const [chosenExpressionName, setExpressionName] = useState(selectedExpressionName);
+  const [dataTypeSelectOpen, setDataTypeSelectOpen] = useState(false);
+  const [dataType, setDataType] = useState(selectedDataType);
+  const [expressionName, setExpressionName] = useState(selectedExpressionName);
 
   const onExpressionNameChange = useCallback(
     (event) => {
@@ -67,11 +67,11 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
       if (event.type === "blur") {
         onExpressionUpdate({
           name: event.target.value,
-          dataType: chosenDataType,
+          dataType,
         });
       }
     },
-    [chosenDataType, onExpressionUpdate]
+    [dataType, onExpressionUpdate]
   );
 
   const onDataTypeSelect = useCallback(
@@ -79,11 +79,11 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
       setDataTypeSelectOpen(false);
       setDataType(selection);
       onExpressionUpdate({
-        name: chosenExpressionName,
+        name: expressionName,
         dataType: selection,
       });
     },
-    [chosenExpressionName, onExpressionUpdate]
+    [expressionName, onExpressionUpdate]
   );
 
   const getDataTypes = useCallback(() => {
@@ -121,7 +121,7 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
             <input
               type="text"
               id="expression-name"
-              value={chosenExpressionName}
+              value={expressionName}
               onChange={onExpressionNameChange}
               onBlur={onExpressionNameChange}
               className="form-control pf-c-form-control"
@@ -136,8 +136,8 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
               onToggle={onDataTypeSelectToggle}
               onSelect={onDataTypeSelect}
               onFilter={onDataTypeFilter}
-              isOpen={dataTypeSelectIsOpen}
-              selections={chosenDataType}
+              isOpen={dataTypeSelectOpen}
+              selections={dataType}
               hasInlineFilter
               inlineFilterPlaceholderText={i18n.choose}
             >

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
@@ -34,6 +34,7 @@
 
 .expression-container > .expression-container-box.logic-type-selected {
   cursor: default;
+  padding: 10px;
 }
 
 .expression-container > .expression-container-box,

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
@@ -28,6 +28,10 @@
   display: -webkit-flex;
 }
 
+.expression-container .context-menu-container {
+  position: absolute;
+}
+
 .expression-container > .expression-container-box.logic-type-not-present {
   cursor: pointer;
 }
@@ -42,17 +46,4 @@
   font-size: smaller;
   font-style: italic;
   color: gray;
-}
-
-.expression-actions .pf-c-dropdown .pf-c-dropdown__menu,
-.expression-actions-toggle {
-  padding: 0;
-}
-
-.expression-actions .pf-c-dropdown a {
-  font-size: var(--small-font-size);
-}
-
-.expression-container .expression-actions .pf-c-dropdown button:focus {
-  outline-width: 0;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
@@ -30,6 +30,7 @@
 
 .expression-container .context-menu-container {
   position: absolute;
+  z-index: 10000;
 }
 
 .expression-container > .expression-container-box.logic-type-not-present {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -67,9 +67,7 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
         dataType: previousSelectedExpression.dataType,
         logicType: LogicType.Undefined,
       };
-      if (window.beeApi?.resetExpressionDefinition) {
-        window.beeApi.resetExpressionDefinition(updatedExpression);
-      }
+      window.beeApi?.resetExpressionDefinition?.(updatedExpression);
       return updatedExpression;
     });
   }, []);

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -61,11 +61,17 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
 
   const executeClearAction = useCallback(() => {
     setLogicTypeSelected(false);
-    setSelectedExpression((previousSelectedExpression: ExpressionProps) => ({
-      name: previousSelectedExpression.name,
-      dataType: previousSelectedExpression.dataType,
-      logicType: LogicType.Undefined,
-    }));
+    setSelectedExpression((previousSelectedExpression: ExpressionProps) => {
+      const updatedExpression = {
+        name: previousSelectedExpression.name,
+        dataType: previousSelectedExpression.dataType,
+        logicType: LogicType.Undefined,
+      };
+      if (window.beeApi?.resetExpressionDefinition) {
+        window.beeApi.resetExpressionDefinition(updatedExpression);
+      }
+      return updatedExpression;
+    });
   }, []);
 
   const onDropdownToggle = useCallback((isOpen) => {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -136,7 +136,7 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
       case LogicType.LiteralExpression:
         return (
           <LiteralExpression
-            updateNameAndDataTypeCallback={updateNameAndDataType}
+            onUpdatingNameAndDataType={updateNameAndDataType}
             {...(selectedExpression as LiteralExpressionProps)}
           />
         );

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -41,10 +41,10 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
 ) => {
   const { i18n } = useBoxedExpressionEditorI18n();
 
-  const [logicTypeIsPresent, setLogicTypeSelected] = useState(
+  const [logicTypeSelected, setLogicTypeSelected] = useState(
     !_.isEmpty(props.selectedExpression.logicType) || props.selectedExpression.logicType === LogicType.Undefined
   );
-  const [actionDropdownIsOpen, setActionDropDownOpen] = useState(false);
+  const [actionDropdownOpen, setActionDropDownOpen] = useState(false);
   const [selectedExpression, setSelectedExpression] = useState(props.selectedExpression);
 
   const onLogicTypeSelect = useCallback(
@@ -88,10 +88,10 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
       <Dropdown
         onSelect={onExpressionActionDropdownSelect}
         toggle={<KebabToggle onToggle={onDropdownToggle} className="expression-actions-toggle" />}
-        isOpen={actionDropdownIsOpen}
+        isOpen={actionDropdownOpen}
         isPlain
         dropdownItems={[
-          <DropdownItem key="clear" onClick={executeClearAction} isDisabled={!logicTypeIsPresent}>
+          <DropdownItem key="clear" onClick={executeClearAction} isDisabled={!logicTypeSelected}>
             {i18n.clear}
           </DropdownItem>,
         ]}
@@ -101,8 +101,8 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
     i18n.clear,
     onExpressionActionDropdownSelect,
     onDropdownToggle,
-    actionDropdownIsOpen,
-    logicTypeIsPresent,
+    actionDropdownOpen,
+    logicTypeSelected,
     executeClearAction,
   ]);
 
@@ -164,12 +164,12 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
       <span className="expression-actions">{renderExpressionActionsDropdown()}</span>
 
       <div
-        className={`expression-container-box ${logicTypeIsPresent ? "logic-type-selected" : "logic-type-not-present"}`}
+        className={`expression-container-box ${logicTypeSelected ? "logic-type-selected" : "logic-type-not-present"}`}
       >
         {selectedExpression.logicType ? renderSelectedExpression : i18n.selectExpression}
       </div>
 
-      {!logicTypeIsPresent ? buildLogicSelectorMenu() : null}
+      {!logicTypeSelected ? buildLogicSelectorMenu() : null}
     </div>
   );
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -40,13 +40,13 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
   );
   const [selectedExpression, setSelectedExpression] = useState(props.selectedExpression);
 
-  const [
+  const {
     contextMenuRef,
     contextMenuXPos,
     contextMenuYPos,
-    contextMenuIsVisible,
+    contextMenuVisibility,
     setContextMenuVisibility,
-  ] = useContextMenuHandler();
+  } = useContextMenuHandler();
 
   const onLogicTypeSelect = useCallback(
     (currentItem: React.RefObject<HTMLButtonElement>, currentItemProps: SimpleListItemProps) => {
@@ -159,7 +159,7 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
       </div>
 
       {!logicTypeSelected ? buildLogicSelectorMenu() : null}
-      {contextMenuIsVisible ? buildContextMenu() : null}
+      {contextMenuVisibility ? buildContextMenu() : null}
     </div>
   );
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
@@ -16,7 +16,6 @@
 
 .literal-expression {
   width: 300px;
-  margin: 10px;
 }
 
 .literal-expression .literal-expression-header {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
@@ -16,8 +16,8 @@
 
 import "./LiteralExpression.css";
 import * as React from "react";
-import { useCallback, useState } from "react";
-import { ExpressionProps, LiteralExpressionProps } from "../../api";
+import { useCallback, useEffect, useState } from "react";
+import { ExpressionProps, LiteralExpressionProps, LogicType } from "../../api";
 import { TextArea } from "@patternfly/react-core";
 import { EditExpressionMenu } from "../EditExpressionMenu";
 
@@ -31,6 +31,17 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
   const [expressionDataType, setExpressionDataType] = useState(dataType);
   const [literalExpressionContent, setLiteralExpressionContent] = useState(content);
 
+  useEffect(() => {
+    if (window.beeApi?.broadcastLiteralExpressionDefinition) {
+      window.beeApi.broadcastLiteralExpressionDefinition({
+        name: expressionName,
+        dataType: expressionDataType,
+        logicType: LogicType.LiteralExpression,
+        content: literalExpressionContent,
+      });
+    }
+  });
+
   const onExpressionUpdate = useCallback(
     ({ dataType, name }: ExpressionProps) => {
       setExpressionName(name);
@@ -42,7 +53,8 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
     [onUpdatingNameAndDataType]
   );
 
-  const onContentChange = useCallback((updatedContent) => {
+  const onContentChange = useCallback((event) => {
+    const updatedContent = event.target.value;
     setLiteralExpressionContent(updatedContent);
   }, []);
 
@@ -60,7 +72,7 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
       <div className="literal-expression-body">
         <TextArea
           defaultValue={literalExpressionContent}
-          onChange={onContentChange}
+          onBlur={onContentChange}
           aria-label="literal-expression-content"
         />
       </div>

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
@@ -33,7 +33,7 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
   const [literalExpressionContent, setLiteralExpressionContent] = useState(content);
 
   useEffect(() => {
-    window.beeApi.broadcastLiteralExpressionDefinition?.({
+    window.beeApi?.broadcastLiteralExpressionDefinition?.({
       name: expressionName,
       dataType: expressionDataType,
       logicType: LogicType.LiteralExpression,

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
@@ -25,7 +25,7 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
   content,
   dataType,
   name,
-  updateNameAndDataTypeCallback,
+  onUpdatingNameAndDataType,
 }: LiteralExpressionProps) => {
   const [expressionName, setExpressionName] = useState(name);
   const [expressionDataType, setExpressionDataType] = useState(dataType);
@@ -35,11 +35,11 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
     ({ dataType, name }: ExpressionProps) => {
       setExpressionName(name);
       setExpressionDataType(dataType);
-      if (updateNameAndDataTypeCallback && dataType) {
-        updateNameAndDataTypeCallback(name, dataType);
+      if (onUpdatingNameAndDataType) {
+        onUpdatingNameAndDataType(name, dataType);
       }
     },
-    [updateNameAndDataTypeCallback]
+    [onUpdatingNameAndDataType]
   );
 
   const onContentChange = useCallback((updatedContent) => {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
@@ -39,7 +39,7 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
       logicType: LogicType.LiteralExpression,
       content: literalExpressionContent,
     });
-  });
+  }, [expressionName, expressionDataType, literalExpressionContent]);
 
   const onExpressionUpdate = useCallback(
     ({ dataType, name }: ExpressionProps) => {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
@@ -33,14 +33,12 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
   const [literalExpressionContent, setLiteralExpressionContent] = useState(content);
 
   useEffect(() => {
-    if (window.beeApi?.broadcastLiteralExpressionDefinition) {
-      window.beeApi.broadcastLiteralExpressionDefinition({
-        name: expressionName,
-        dataType: expressionDataType,
-        logicType: LogicType.LiteralExpression,
-        content: literalExpressionContent,
-      });
-    }
+    window.beeApi.broadcastLiteralExpressionDefinition?.({
+      name: expressionName,
+      dataType: expressionDataType,
+      logicType: LogicType.LiteralExpression,
+      content: literalExpressionContent,
+    });
   });
 
   const onExpressionUpdate = useCallback(

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
@@ -26,6 +26,7 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
   dataType,
   name,
   onUpdatingNameAndDataType,
+  isHeadless = false,
 }: LiteralExpressionProps) => {
   const [expressionName, setExpressionName] = useState(name);
   const [expressionDataType, setExpressionDataType] = useState(dataType);
@@ -63,12 +64,19 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
     []
   );
 
-  return (
-    <div className="literal-expression">
+  const renderLiteralExpressionHeader = useCallback(
+    () => (
       <div className="literal-expression-header">
         <p className="expression-name">{expressionName}</p>
         <p className="expression-data-type">({expressionDataType})</p>
       </div>
+    ),
+    [expressionDataType, expressionName]
+  );
+
+  return (
+    <div className="literal-expression">
+      {!isHeadless ? renderLiteralExpressionHeader() : null}
       <div className="literal-expression-body">
         <TextArea
           defaultValue={literalExpressionContent}

--- a/kie-wb-common-react/boxed-expression-editor/src/hooks/Hooks.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/hooks/Hooks.ts
@@ -27,11 +27,11 @@ export function useContextMenuHandler(): [
 
   const [xPos, setXPos] = useState("0px");
   const [yPos, setYPos] = useState("0px");
-  const [contextMenuIsVisible, setContextMenuVisibility] = useState(false);
+  const [contextMenuVisible, setContextMenuVisible] = useState(false);
 
   const hideContextMenu = useCallback(() => {
-    contextMenuIsVisible && setContextMenuVisibility(false);
-  }, [contextMenuIsVisible]);
+    contextMenuVisible && setContextMenuVisible(false);
+  }, [contextMenuVisible]);
 
   const showContextMenu = useCallback(
     (event: MouseEvent) => {
@@ -39,7 +39,7 @@ export function useContextMenuHandler(): [
         event.preventDefault();
         setXPos(`${event.pageX}px`);
         setYPos(`${event.pageY}px`);
-        setContextMenuVisibility(true);
+        setContextMenuVisible(true);
       }
     },
     [setXPos, setYPos]
@@ -54,5 +54,5 @@ export function useContextMenuHandler(): [
     };
   });
 
-  return [wrapperRef, xPos, yPos, contextMenuIsVisible, setContextMenuVisibility];
+  return [wrapperRef, xPos, yPos, contextMenuVisible, setContextMenuVisible];
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/hooks/Hooks.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/hooks/Hooks.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Dispatch, RefObject, SetStateAction, useCallback, useEffect, useRef, useState } from "react";
+
+export function useContextMenuHandler(): [
+  RefObject<HTMLDivElement>,
+  string,
+  string,
+  boolean,
+  Dispatch<SetStateAction<boolean>>
+] {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const [xPos, setXPos] = useState("0px");
+  const [yPos, setYPos] = useState("0px");
+  const [contextMenuIsVisible, setContextMenuVisibility] = useState(false);
+
+  const hideContextMenu = useCallback(() => {
+    contextMenuIsVisible && setContextMenuVisibility(false);
+  }, [contextMenuIsVisible]);
+
+  const showContextMenu = useCallback(
+    (event: MouseEvent) => {
+      if (wrapperRef.current && wrapperRef.current === event.target) {
+        event.preventDefault();
+        setXPos(`${event.pageX}px`);
+        setYPos(`${event.pageY}px`);
+        setContextMenuVisibility(true);
+      }
+    },
+    [setXPos, setYPos]
+  );
+
+  useEffect(() => {
+    document.addEventListener("click", hideContextMenu);
+    document.addEventListener("contextmenu", showContextMenu);
+    return () => {
+      document.removeEventListener("click", hideContextMenu);
+      document.removeEventListener("contextmenu", showContextMenu);
+    };
+  });
+
+  return [wrapperRef, xPos, yPos, contextMenuIsVisible, setContextMenuVisibility];
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/hooks/Hooks.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/hooks/Hooks.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import { Dispatch, RefObject, SetStateAction, useCallback, useEffect, useRef, useState } from "react";
+import { RefObject, useCallback, useEffect, useRef, useState } from "react";
 
-export function useContextMenuHandler(): [
-  RefObject<HTMLDivElement>,
-  string,
-  string,
-  boolean,
-  Dispatch<SetStateAction<boolean>>
-] {
+export function useContextMenuHandler(): {
+  contextMenuRef: RefObject<HTMLDivElement>;
+  contextMenuXPos: string;
+  contextMenuYPos: string;
+  contextMenuVisibility: boolean;
+  setContextMenuVisibility: (value: ((prevState: boolean) => boolean) | boolean) => void;
+} {
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   const [xPos, setXPos] = useState("0px");
@@ -54,5 +54,11 @@ export function useContextMenuHandler(): [
     };
   });
 
-  return [wrapperRef, xPos, yPos, contextMenuVisible, setContextMenuVisible];
+  return {
+    contextMenuRef: wrapperRef,
+    contextMenuXPos: xPos,
+    contextMenuYPos: yPos,
+    contextMenuVisibility: contextMenuVisible,
+    setContextMenuVisibility: setContextMenuVisible,
+  };
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/hooks/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/hooks/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./Hooks";


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/KOGITO-3952

**Referenced Pull Requests**:
This PR **must be merged** after this one:
* https://github.com/vpellegrino/kie-wb-common/pull/9

![KOGITO-3952](https://user-images.githubusercontent.com/22591802/101646057-58a8c580-3a37-11eb-800d-ed778a4ff81c.gif)

**BoxedExpressionEditor** component is expecting a namespace, with several functions exposed. A function for each logic type will enable to pass updated expression definition.
In the _showcase_ app, we are exposing such functions, in order to collect expression definition and display its JSON on the right.

**Try it out**: https://cutt.ly/boxed-expression-editor