### PR TITLE
Switching from actions menu to context menu for the 'clear' action

### DIFF
--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/__snapshots__/BoxedExpressionEditor.test.tsx.snap
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/__snapshots__/BoxedExpressionEditor.test.tsx.snap
@@ -17,39 +17,6 @@ exports[`BoxedExpressionEditor tests should render BoxedExpressionEditor compone
       &lt;Undefined&gt;
       )
     </span>
-    <span
-      class="expression-actions"
-    >
-      <div
-        class="pf-c-dropdown"
-        data-ouia-component-id="OUIA-Generated-Dropdown-1"
-        data-ouia-component-type="PF4/Dropdown"
-        data-ouia-safe="true"
-      >
-        <button
-          aria-expanded="false"
-          aria-haspopup="true"
-          aria-label="Actions"
-          class="pf-c-dropdown__toggle pf-m-plain expression-actions-toggle"
-          id="pf-dropdown-toggle-id-0"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 192 512"
-            width="1em"
-          >
-            <path
-              d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-            />
-          </svg>
-        </button>
-      </div>
-    </span>
     <div
       class="expression-container-box logic-type-not-present"
     >

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/__snapshots__/ExpressionContainer.test.tsx.snap
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ExpressionContainer/__snapshots__/ExpressionContainer.test.tsx.snap
@@ -17,39 +17,6 @@ exports[`ExpressionContainer tests should render ExpressionContainer component 1
       &lt;Undefined&gt;
       )
     </span>
-    <span
-      class="expression-actions"
-    >
-      <div
-        class="pf-c-dropdown"
-        data-ouia-component-id="OUIA-Generated-Dropdown-1"
-        data-ouia-component-type="PF4/Dropdown"
-        data-ouia-safe="true"
-      >
-        <button
-          aria-expanded="false"
-          aria-haspopup="true"
-          aria-label="Actions"
-          class="pf-c-dropdown__toggle pf-m-plain expression-actions-toggle"
-          id="pf-dropdown-toggle-id-0"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 192 512"
-            width="1em"
-          >
-            <path
-              d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-            />
-          </svg>
-        </button>
-      </div>
-    </span>
     <div
       class="expression-container-box logic-type-not-present"
     >

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
@@ -34,6 +34,7 @@
 
 .expression-container > .expression-container-box.logic-type-selected {
   cursor: default;
+  padding: 10px;
 }
 
 .expression-container > .expression-container-box,

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
@@ -28,6 +28,10 @@
   display: -webkit-flex;
 }
 
+.expression-container .context-menu-container {
+  position: absolute;
+}
+
 .expression-container > .expression-container-box.logic-type-not-present {
   cursor: pointer;
 }
@@ -42,17 +46,4 @@
   font-size: smaller;
   font-style: italic;
   color: gray;
-}
-
-.expression-actions .pf-c-dropdown .pf-c-dropdown__menu,
-.expression-actions-toggle {
-  padding: 0;
-}
-
-.expression-actions .pf-c-dropdown a {
-  font-size: var(--small-font-size);
-}
-
-.expression-container .expression-actions .pf-c-dropdown button:focus {
-  outline-width: 0;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
@@ -30,6 +30,7 @@
 
 .expression-container .context-menu-container {
   position: absolute;
+  z-index: 10000;
 }
 
 .expression-container > .expression-container-box.logic-type-not-present {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -40,13 +40,13 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
   );
   const [selectedExpression, setSelectedExpression] = useState(props.selectedExpression);
 
-  const [
+  const {
     contextMenuRef,
     contextMenuXPos,
     contextMenuYPos,
-    contextMenuIsVisible,
+    contextMenuVisibility,
     setContextMenuVisibility,
-  ] = useContextMenuHandler();
+  } = useContextMenuHandler();
 
   const onLogicTypeSelect = useCallback(
     (currentItem: React.RefObject<HTMLButtonElement>, currentItemProps: SimpleListItemProps) => {
@@ -159,7 +159,7 @@ export const ExpressionContainer: ({ selectedExpression }: ExpressionContainerPr
       </div>
 
       {!logicTypeSelected ? buildLogicSelectorMenu() : null}
-      {contextMenuIsVisible ? buildContextMenu() : null}
+      {contextMenuVisibility ? buildContextMenu() : null}
     </div>
   );
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
@@ -16,7 +16,6 @@
 
 .literal-expression {
   width: 300px;
-  margin: 10px;
 }
 
 .literal-expression .literal-expression-header {

--- a/kie-wb-common-react/boxed-expression-editor/src/hooks/Hooks.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/hooks/Hooks.ts
@@ -27,11 +27,11 @@ export function useContextMenuHandler(): [
 
   const [xPos, setXPos] = useState("0px");
   const [yPos, setYPos] = useState("0px");
-  const [contextMenuIsVisible, setContextMenuVisibility] = useState(false);
+  const [contextMenuVisible, setContextMenuVisible] = useState(false);
 
   const hideContextMenu = useCallback(() => {
-    contextMenuIsVisible && setContextMenuVisibility(false);
-  }, [contextMenuIsVisible]);
+    contextMenuVisible && setContextMenuVisible(false);
+  }, [contextMenuVisible]);
 
   const showContextMenu = useCallback(
     (event: MouseEvent) => {
@@ -39,7 +39,7 @@ export function useContextMenuHandler(): [
         event.preventDefault();
         setXPos(`${event.pageX}px`);
         setYPos(`${event.pageY}px`);
-        setContextMenuVisibility(true);
+        setContextMenuVisible(true);
       }
     },
     [setXPos, setYPos]
@@ -54,5 +54,5 @@ export function useContextMenuHandler(): [
     };
   });
 
-  return [wrapperRef, xPos, yPos, contextMenuIsVisible, setContextMenuVisibility];
+  return [wrapperRef, xPos, yPos, contextMenuVisible, setContextMenuVisible];
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/hooks/Hooks.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/hooks/Hooks.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Dispatch, RefObject, SetStateAction, useCallback, useEffect, useRef, useState } from "react";
+
+export function useContextMenuHandler(): [
+  RefObject<HTMLDivElement>,
+  string,
+  string,
+  boolean,
+  Dispatch<SetStateAction<boolean>>
+] {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const [xPos, setXPos] = useState("0px");
+  const [yPos, setYPos] = useState("0px");
+  const [contextMenuIsVisible, setContextMenuVisibility] = useState(false);
+
+  const hideContextMenu = useCallback(() => {
+    contextMenuIsVisible && setContextMenuVisibility(false);
+  }, [contextMenuIsVisible]);
+
+  const showContextMenu = useCallback(
+    (event: MouseEvent) => {
+      if (wrapperRef.current && wrapperRef.current === event.target) {
+        event.preventDefault();
+        setXPos(`${event.pageX}px`);
+        setYPos(`${event.pageY}px`);
+        setContextMenuVisibility(true);
+      }
+    },
+    [setXPos, setYPos]
+  );
+
+  useEffect(() => {
+    document.addEventListener("click", hideContextMenu);
+    document.addEventListener("contextmenu", showContextMenu);
+    return () => {
+      document.removeEventListener("click", hideContextMenu);
+      document.removeEventListener("contextmenu", showContextMenu);
+    };
+  });
+
+  return [wrapperRef, xPos, yPos, contextMenuIsVisible, setContextMenuVisibility];
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/hooks/Hooks.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/hooks/Hooks.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import { Dispatch, RefObject, SetStateAction, useCallback, useEffect, useRef, useState } from "react";
+import { RefObject, useCallback, useEffect, useRef, useState } from "react";
 
-export function useContextMenuHandler(): [
-  RefObject<HTMLDivElement>,
-  string,
-  string,
-  boolean,
-  Dispatch<SetStateAction<boolean>>
-] {
+export function useContextMenuHandler(): {
+  contextMenuRef: RefObject<HTMLDivElement>;
+  contextMenuXPos: string;
+  contextMenuYPos: string;
+  contextMenuVisibility: boolean;
+  setContextMenuVisibility: (value: ((prevState: boolean) => boolean) | boolean) => void;
+} {
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   const [xPos, setXPos] = useState("0px");
@@ -54,5 +54,11 @@ export function useContextMenuHandler(): [
     };
   });
 
-  return [wrapperRef, xPos, yPos, contextMenuVisible, setContextMenuVisible];
+  return {
+    contextMenuRef: wrapperRef,
+    contextMenuXPos: xPos,
+    contextMenuYPos: yPos,
+    contextMenuVisibility: contextMenuVisible,
+    setContextMenuVisibility: setContextMenuVisible,
+  };
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/hooks/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/hooks/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./Hooks";


### PR DESCRIPTION
**Context**: At the beginning, there was a kebab menu with an action menu for clearing the boxed expression. Now switching back to what it is in place in the "GWT world". So, for clearing an expression consider that a boxed expression has a border around it. Right-click in this border and you can clear it.

**Referenced Pull Requests**:
This PR **must be merged** before this one:
* https://github.com/vpellegrino/kie-wb-common/pull/8

![right-click-context-menu](https://user-images.githubusercontent.com/22591802/101990952-b2b0c180-3ca9-11eb-830c-6f6d08365b61.gif)

**Try it out**: https://cutt.ly/boxed-expression-editor