### PR TITLE
KOGITO-4264: In the DMN boxed expression editor React PoC, implement a draft integration for loading/saving Literal, Relation and Context logic types

### DIFF
--- a/kie-wb-common-react/boxed-expression-editor/showcase/src/index.css
+++ b/kie-wb-common-react/boxed-expression-editor/showcase/src/index.css
@@ -17,7 +17,7 @@
 .showcase {
   display: flex;
   flex-direction: column;
-  padding: 2em;
+  padding: 1.5em;
 }
 
 .showcase .boxed-expression {
@@ -36,4 +36,5 @@
 .showcase .updated-json .disclaimer {
   font-style: italic;
   color: #4d5258;
+  margin: 0;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/__snapshots__/BoxedExpressionEditor.test.tsx.snap
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/__snapshots__/BoxedExpressionEditor.test.tsx.snap
@@ -3,32 +3,36 @@
 exports[`BoxedExpressionEditor tests should render BoxedExpressionEditor component 1`] = `
 <div>
   <div
-    class="expression-container"
+    class="boxed-expression-editor"
   >
     <div
-      class="expression-name-and-logic-type"
-    >
-      <span
-        class="expression-title"
-      >
-        Expression Name
-      </span>
-      <span
-        class="expression-type"
-      >
-        (
-        &lt;Undefined&gt;
-        )
-      </span>
-    </div>
-    <div
-      class="expression-container-box"
-      data-ouia-component-id="expression-container"
+      class="expression-container"
     >
       <div
-        class="logic-type-selector no-table-context-menu logic-type-not-present"
+        class="expression-name-and-logic-type"
       >
-        Select expression
+        <span
+          class="expression-title"
+        >
+          Expression Name
+        </span>
+        <span
+          class="expression-type"
+        >
+          (
+          &lt;Undefined&gt;
+          )
+        </span>
+      </div>
+      <div
+        class="expression-container-box"
+        data-ouia-component-id="expression-container"
+      >
+        <div
+          class="logic-type-selector no-table-context-menu logic-type-not-present"
+        >
+          Select expression
+        </div>
       </div>
     </div>
   </div>

--- a/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.css
@@ -15,5 +15,69 @@
  */
 
 .boxed-expression-editor {
+  background-color: var(--pf-global--BackgroundColor--100);
+  font-family: var(--pf-global--FontFamily--sans-serif);
+  font-size: var(--pf-global--FontSize--md);
+  font-weight: var(--pf-global--FontWeight--normal);
+  line-height: var(--pf-global--LineHeight--md);
+  text-align: left;
+}
 
- }
+.boxed-expression-editor *, .boxed-expression-editor *:after, .boxed-expression-editor *:before {
+  box-sizing: border-box;
+}
+
+.boxed-expression-editor a, .boxed-expression-editor button {
+  cursor: pointer;
+}
+
+.boxed-expression-editor table {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+.boxed-expression-editor .pf-c-menu__group-title {
+  padding: var(--pf-c-menu__group-title--PaddingTop) var(--pf-c-menu__group-title--PaddingRight) var(--pf-c-menu__group-title--PaddingBottom) var(--pf-c-menu__group-title--PaddingLeft);
+  font-weight: var(--pf-c-menu__group-title--FontWeight);
+  color: var(--pf-c-menu__group-title--Color);
+}
+
+.boxed-expression-editor .pf-c-menu__item {
+  color: var(--pf-c-menu__item--Color);
+}
+
+.boxed-expression-editor button,
+.boxed-expression-editor input,
+.boxed-expression-editor optgroup,
+.boxed-expression-editor select,
+.boxed-expression-editor textarea {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: var(--pf-global--LineHeight--md);
+  color: var(--pf-global--Color--100);
+}
+
+.boxed-expression-editor blockquote,
+.boxed-expression-editor dd,
+.boxed-expression-editor dl,
+.boxed-expression-editor dt,
+.boxed-expression-editor fieldset,
+.boxed-expression-editor figure,
+.boxed-expression-editor h1,
+.boxed-expression-editor h2,
+.boxed-expression-editor h3,
+.boxed-expression-editor h4,
+.boxed-expression-editor h5,
+.boxed-expression-editor h6,
+.boxed-expression-editor hr,
+.boxed-expression-editor iframe,
+.boxed-expression-editor legend,
+.boxed-expression-editor li,
+.boxed-expression-editor ol,
+.boxed-expression-editor p,
+.boxed-expression-editor pre,
+.boxed-expression-editor textarea,
+.boxed-expression-editor ul {
+  padding: 0;
+  margin: 0;
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.css
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.boxed-expression-editor {
+
+ }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
@@ -15,9 +15,10 @@
  */
 
 import * as React from "react";
-import { useState } from "react";
-import "@patternfly/react-core/dist/styles/base.css";
+import { useRef, useState } from "react";
+import "@patternfly/react-core/dist/styles/base-no-reset.css";
 import "@patternfly/react-styles/css/components/Drawer/drawer.css";
+import "./BoxedExpressionEditor.css";
 import { I18nDictionariesProvider } from "@kogito-tooling/i18n/dist/react-components";
 import { ExpressionContainer, ExpressionContainerProps } from "../ExpressionContainer";
 import {
@@ -37,6 +38,7 @@ const BoxedExpressionEditor: (props: BoxedExpressionEditorProps) => JSX.Element 
   props: BoxedExpressionEditorProps
 ) => {
   const [currentlyOpenedHandlerCallback, setCurrentlyOpenedHandlerCallback] = useState(() => _.identity);
+  const boxedExpressionEditorRef = useRef<HTMLDivElement>(null);
 
   return (
     <I18nDictionariesProvider
@@ -48,7 +50,9 @@ const BoxedExpressionEditor: (props: BoxedExpressionEditorProps) => JSX.Element 
       <BoxedExpressionGlobalContext.Provider
         value={{ currentlyOpenedHandlerCallback, setCurrentlyOpenedHandlerCallback }}
       >
-        <ExpressionContainer {...props.expressionDefinition} />
+        <div className="boxed-expression-editor" ref={boxedExpressionEditorRef}>
+          <ExpressionContainer {...props.expressionDefinition} />
+        </div>
       </BoxedExpressionGlobalContext.Provider>
     </I18nDictionariesProvider>
   );

--- a/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
@@ -48,7 +48,7 @@ const BoxedExpressionEditor: (props: BoxedExpressionEditorProps) => JSX.Element 
       ctx={BoxedExpressionEditorI18nContext}
     >
       <BoxedExpressionGlobalContext.Provider
-        value={{ currentlyOpenedHandlerCallback, setCurrentlyOpenedHandlerCallback }}
+        value={{ boxedExpressionEditorRef, currentlyOpenedHandlerCallback, setCurrentlyOpenedHandlerCallback }}
       >
         <div className="boxed-expression-editor" ref={boxedExpressionEditorRef}>
           <ExpressionContainer {...props.expressionDefinition} />

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
@@ -16,12 +16,13 @@
 
 import "./EditExpressionMenu.css";
 import * as React from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { PopoverMenu } from "../PopoverMenu";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { DataType, ExpressionProps } from "../../api";
 import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";
 import * as _ from "lodash";
+import { BoxedExpressionGlobalContext } from "../../context";
 
 export interface EditExpressionMenuProps {
   /** Optional children element to be considered for triggering the edit expression menu */
@@ -57,10 +58,12 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
   selectedExpressionName,
   onExpressionUpdate,
 }: EditExpressionMenuProps) => {
+  const globalContext = useContext(BoxedExpressionGlobalContext);
   const { i18n } = useBoxedExpressionEditorI18n();
   title = title ?? i18n.editExpression;
   nameField = nameField ?? i18n.name;
   dataTypeField = dataTypeField ?? i18n.dataType;
+  appendTo = appendTo ?? globalContext.boxedExpressionEditorRef?.current ?? undefined;
 
   const [dataTypeSelectOpen, setDataTypeSelectOpen] = useState(false);
   const [dataType, setDataType] = useState(selectedDataType);

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
@@ -48,7 +48,7 @@
   color: black;
 }
 
-.literal-expression .literal-expression-header .expression-data-type {
+.literal-expression .literal-expression-header .expression-name {
   font-style: normal;
 }
 
@@ -57,6 +57,7 @@
 }
 
 .literal-expression .literal-expression-body textarea {
+  border-style: groove;
   font-style: normal;
   padding: 0.5em 0.5em 0 0.5em;
   width: 100%;

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
@@ -49,7 +49,7 @@
 }
 
 .literal-expression .literal-expression-header .expression-data-type {
-   font-style: normal;
+  font-style: normal;
 }
 
 .literal-expression .literal-expression-body {
@@ -57,7 +57,8 @@
 }
 
 .literal-expression .literal-expression-body textarea {
-  padding-bottom: 0;
+  font-style: normal;
+  padding: 0.5em 0.5em 0 0.5em;
   width: 100%;
   height: 100%;
   resize: none;

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
@@ -34,6 +34,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  font-weight: 700;
 }
 
 .literal-expression .literal-expression-header {
@@ -41,7 +42,7 @@
   justify-content: center;
   flex-wrap: wrap;
   position: relative;
-  padding: 5px;
+  padding: 0.5em 0.8em 0.5em 0.5em;
   border-style: ridge;
   background-color: #DEF3FF;
   color: black;

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.tsx
@@ -129,6 +129,7 @@ export const LogicTypeSelector: React.FunctionComponent<LogicTypeSelectorProps> 
       <PopoverMenu
         title={i18n.selectLogicType}
         arrowPlacement={getLogicSelectionArrowPlacement}
+        appendTo={getLogicSelectionArrowPlacement}
         className="logic-type-popover"
         hasAutoWidth
         body={

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.tsx
@@ -16,7 +16,7 @@
 
 import "./LogicTypeSelector.css";
 import * as React from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { ContextProps, DataType, ExpressionProps, LiteralExpressionProps, LogicType, RelationProps } from "../../api";
 import { LiteralExpression } from "../LiteralExpression";
 import { RelationExpression } from "../RelationExpression";
@@ -28,6 +28,7 @@ import * as _ from "lodash";
 import { useContextMenuHandler } from "../../hooks";
 import { NO_TABLE_CONTEXT_MENU_CLASS } from "../Table";
 import nextId from "react-id-generator";
+import { BoxedExpressionGlobalContext } from "../../context";
 
 export interface LogicTypeSelectorProps {
   /** Expression properties */
@@ -56,6 +57,8 @@ export const LogicTypeSelector: React.FunctionComponent<LogicTypeSelectorProps> 
   onUpdatingRecursiveExpression,
 }) => {
   const { i18n } = useBoxedExpressionEditorI18n();
+
+  const globalContext = useContext(BoxedExpressionGlobalContext);
 
   const expression = _.extend(selectedExpression, {
     isHeadless,
@@ -113,7 +116,11 @@ export const LogicTypeSelector: React.FunctionComponent<LogicTypeSelectorProps> 
     [getLogicTypesWithoutUndefined]
   );
 
-  const getLogicSelectionArrowPlacement = useCallback(() => getPlacementRef() as HTMLElement, [getPlacementRef]);
+  const getArrowPlacement = useCallback(() => getPlacementRef() as HTMLElement, [getPlacementRef]);
+
+  const getAppendToPlacement = useCallback(() => {
+    return globalContext.boxedExpressionEditorRef?.current ?? getArrowPlacement;
+  }, [getArrowPlacement, globalContext.boxedExpressionEditorRef]);
 
   const onLogicTypeSelect = useCallback(
     (event: MouseEvent, itemId: string) => {
@@ -128,8 +135,8 @@ export const LogicTypeSelector: React.FunctionComponent<LogicTypeSelectorProps> 
     () => (
       <PopoverMenu
         title={i18n.selectLogicType}
-        arrowPlacement={getLogicSelectionArrowPlacement}
-        appendTo={getLogicSelectionArrowPlacement}
+        arrowPlacement={getArrowPlacement}
+        appendTo={getAppendToPlacement()}
         className="logic-type-popover"
         hasAutoWidth
         body={
@@ -139,7 +146,7 @@ export const LogicTypeSelector: React.FunctionComponent<LogicTypeSelectorProps> 
         }
       />
     ),
-    [i18n.selectLogicType, getLogicSelectionArrowPlacement, onLogicTypeSelect, renderLogicTypeItems]
+    [i18n.selectLogicType, getArrowPlacement, getAppendToPlacement, onLogicTypeSelect, renderLogicTypeItems]
   );
 
   const executeClearAction = useCallback(() => {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.css
@@ -92,7 +92,7 @@
 }
 
 .expression-container .table-component tr > *:last-child {
-  padding-right: 0;
+  padding-right: 0.6em;
 }
 
 .expression-container .table-component table tbody td + td {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.css
@@ -28,10 +28,10 @@
 }
 
 .expression-container .table-component table th {
+  min-height: 55px;
   position: relative;
+  padding: 0.7em;
   border-style: ridge;
-  /** Due to a glitch when resizing column, disabling user selection for header's cells */
-  user-select: none;
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -40,11 +40,6 @@
 
 .expression-container .table-component table th.fixed-column {
   font-weight: 400;
-}
-
-.expression-container .table-component table th .header-cell {
-  height: 55px;
-  position: static;
 }
 
 .expression-container .table-component table th .data-type {
@@ -59,6 +54,14 @@
 .expression-container .table-component table th:not(:first-child) {
   text-align: center;
   background-color: #DEF3FF;
+}
+
+.expression-container .table-component table th.no-clickable-cell:first-of-type .header-cell,
+.expression-container .table-component table th.no-clickable-cell .header-cell-info {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .expression-container .table-component table th:not(.no-clickable-cell) .header-cell-info {
@@ -89,10 +92,6 @@
   padding: 1.1em 0;
   text-align: center;
   overflow: auto;
-}
-
-.expression-container .table-component tr > *:last-child {
-  padding-right: 0.6em;
 }
 
 .expression-container .table-component table tbody td + td {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.css
@@ -47,13 +47,6 @@
   position: static;
 }
 
-.expression-container .table-component table th .header-cell .header-cell-info {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-
 .expression-container .table-component table th .data-type {
   font-style: italic;
   font-size: smaller;

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHandler.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHandler.tsx
@@ -160,7 +160,7 @@ export const TableHandler: React.FunctionComponent<TableHandlerProps> = ({
         shouldClose={() => setShowTableHandler(false)}
         shouldOpen={(showFunction) => showFunction?.()}
         reference={() => tableHandlerTarget}
-        appendTo={globalContext.boxedExpressionEditorRef.current!}
+        appendTo={globalContext?.boxedExpressionEditorRef?.current ?? undefined}
         bodyContent={
           <TableHandlerMenu
             handlerConfiguration={handlerConfiguration}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHandler.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHandler.tsx
@@ -15,12 +15,13 @@
  */
 
 import * as React from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { DataType, TableHandlerConfiguration, TableOperation } from "../../api";
 import * as _ from "lodash";
 import { Column, ColumnInstance, DataRecord } from "react-table";
 import { Popover } from "@patternfly/react-core";
 import { TableHandlerMenu } from "./TableHandlerMenu";
+import { BoxedExpressionGlobalContext } from "../../context";
 
 export interface TableHandlerProps {
   /** The prefix to be used for the column name */
@@ -63,6 +64,8 @@ export const TableHandler: React.FunctionComponent<TableHandlerProps> = ({
   handlerConfiguration,
   tableHandlerAllowedOperations,
 }) => {
+  const globalContext = useContext(BoxedExpressionGlobalContext);
+
   const [selectedColumnIndex, setSelectedColumnIndex] = useState(lastSelectedColumnIndex);
   const [selectedRowIndex, setSelectedRowIndex] = useState(lastSelectedRowIndex);
 
@@ -157,6 +160,7 @@ export const TableHandler: React.FunctionComponent<TableHandlerProps> = ({
         shouldClose={() => setShowTableHandler(false)}
         shouldOpen={(showFunction) => showFunction?.()}
         reference={() => tableHandlerTarget}
+        appendTo={globalContext.boxedExpressionEditorRef.current!}
         bodyContent={
           <TableHandlerMenu
             handlerConfiguration={handlerConfiguration}
@@ -168,6 +172,7 @@ export const TableHandler: React.FunctionComponent<TableHandlerProps> = ({
     ),
     [
       showTableHandler,
+      globalContext.boxedExpressionEditorRef,
       handlerConfiguration,
       tableHandlerAllowedOperations,
       handlingOperation,

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHandler.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHandler.tsx
@@ -160,7 +160,7 @@ export const TableHandler: React.FunctionComponent<TableHandlerProps> = ({
         shouldClose={() => setShowTableHandler(false)}
         shouldOpen={(showFunction) => showFunction?.()}
         reference={() => tableHandlerTarget}
-        appendTo={globalContext?.boxedExpressionEditorRef?.current ?? undefined}
+        appendTo={globalContext.boxedExpressionEditorRef?.current ?? undefined}
         bodyContent={
           <TableHandlerMenu
             handlerConfiguration={handlerConfiguration}

--- a/kie-wb-common-react/boxed-expression-editor/src/context/BoxedExpressionGlobalContext.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/context/BoxedExpressionGlobalContext.tsx
@@ -17,6 +17,7 @@
 import * as React from "react";
 
 export interface BoxedExpressionGlobalContextProps {
+  boxedExpressionEditorRef: React.RefObject<HTMLDivElement>;
   currentlyOpenedHandlerCallback: React.Dispatch<React.SetStateAction<boolean>>;
   setCurrentlyOpenedHandlerCallback: React.Dispatch<
     React.SetStateAction<React.Dispatch<React.SetStateAction<boolean>>>

--- a/kie-wb-common-react/boxed-expression-editor/webpack.dev.js
+++ b/kie-wb-common-react/boxed-expression-editor/webpack.dev.js
@@ -44,7 +44,7 @@ module.exports = merge(common('development'), {
           path.resolve(__dirname, 'node_modules/patternfly'),
           path.resolve(__dirname, 'node_modules/@patternfly/patternfly'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-styles/css'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/base.css'),
+          path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/base-no-reset.css'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/esm/@patternfly/patternfly'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-core/node_modules/@patternfly/react-styles/css'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-table/node_modules/@patternfly/react-styles/css'),

--- a/kie-wb-common-react/boxed-expression-editor/webpack.prod.js
+++ b/kie-wb-common-react/boxed-expression-editor/webpack.prod.js
@@ -46,7 +46,7 @@ module.exports = merge(common('production'), {
           path.resolve(__dirname, 'node_modules/patternfly'),
           path.resolve(__dirname, 'node_modules/@patternfly/patternfly'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-styles/css'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/base.css'),
+          path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/base-no-reset.css'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/esm/@patternfly/patternfly'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-core/node_modules/@patternfly/react-styles/css'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-table/node_modules/@patternfly/react-styles/css'),


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/KOGITO-4264
Please check JIRA description for more information.

Since there is a conflict regarding the global rules defined in PFv3 vs PFv4 (look at https://app.slack.com/client/T293J2PL4/C9Q224EFL/thread/C9Q224EFL-1614271076.016500), for integrating boxed-expression-editor inside existing DMN editor, the steps below have been performed:

1. Import `base-no-reset.css` instead of `base.css`
2. Include missing global rules (from `base.css`) at the root level of `BoxedExpressionEditor` component, so that they will be isolated, but look&feel will be preserved.

![KOGITO-4264](https://user-images.githubusercontent.com/22591802/111142367-e4754500-8584-11eb-9d91-84af02d47091.gif)
