### PR TITLE
KOGITO-3650: Create "Invocation" component

### DIFF
--- a/kie-wb-common-react/boxed-expression-editor/showcase/cypress/integration/invocation_expression_spec.ts
+++ b/kie-wb-common-react/boxed-expression-editor/showcase/cypress/integration/invocation_expression_spec.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <reference types="Cypress" />
+
+describe("Invocation Expression Tests", () => {
+  beforeEach(() => {
+    cy.visit("/");
+  });
+
+  it("Define Invocation expression", () => {
+    // Entry point for each new expression
+    cy.ouiaId("expression-container").click();
+
+    // Define new expression as List
+    cy.ouiaId("expression-popover-menu").contains("Invocation").click({ force: true });
+
+    // Assert some content
+    cy.ouiaId("expression-row-0").should("contain.text", "p-1").should("contain.text", "<Undefined>");
+  });
+});

--- a/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
@@ -18,12 +18,14 @@ import * as React from "react";
 import { useState } from "react";
 import * as ReactDOM from "react-dom";
 import "./index.css";
+// noinspection ES6PreferShortImport
 import {
   BoxedExpressionEditor,
   ContextProps,
   DataType,
   ExpressionContainerProps,
   ExpressionProps,
+  InvocationProps,
   ListProps,
   LiteralExpressionProps,
   RelationProps,
@@ -47,6 +49,7 @@ export const App: React.FunctionComponent = () => {
     broadcastRelationExpressionDefinition: (definition: RelationProps) => setUpdatedExpression(definition),
     broadcastContextExpressionDefinition: (definition: ContextProps) => setUpdatedExpression(definition),
     broadcastListExpressionDefinition: (definition: ListProps) => setUpdatedExpression(definition),
+    broadcastInvocationExpressionDefinition: (definition: InvocationProps) => setUpdatedExpression(definition),
   };
 
   return (
@@ -56,7 +59,7 @@ export const App: React.FunctionComponent = () => {
       </div>
       <div className="updated-json">
         <p className="disclaimer">
-          ⚠ Currently, JSON gets updated only for literal expression, relation, context and list logic types
+          ⚠ Currently, JSON gets updated only for literal expression, relation, context, list and invocation logic types
         </p>
         <pre>{JSON.stringify(updatedExpression, null, 2)}</pre>
       </div>

--- a/kie-wb-common-react/boxed-expression-editor/src/@types/react-table.d.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/@types/react-table.d.ts
@@ -62,8 +62,10 @@ declare module "react-table" {
     dataType: DataType;
     /** When resizable, this function returns the resizer props  */
     getResizerProps: (props?: Partial<TableResizerProps>) => TableResizerProps;
-    /** It tells whether column can resize or not */
+    /** It tells whether column can be resized or not */
     canResize: boolean;
+    /** It tells whether column can be resized on each cell of such column */
+    canResizeOnCell?: boolean;
     /** It tells whether column is of type counter or not */
     isCountColumn: boolean;
     /** Disabling table handler on the header of this column */

--- a/kie-wb-common-react/boxed-expression-editor/src/@types/react-table.d.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/@types/react-table.d.ts
@@ -56,6 +56,8 @@ declare module "react-table" {
     accessor: string;
     /** Column label */
     label: string;
+    /** Custom Element to be rendered in place of the column label */
+    headerCellElement?: JSX.Element;
     /** Column data type */
     dataType: DataType;
     /** When resizable, this function returns the resizer props  */

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextEntryExpressionCell.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextEntryExpressionCell.test.tsx
@@ -42,7 +42,13 @@ describe("ContextEntryExpressionCell tests", () => {
     const { container } = render(
       usingTestingBoxedExpressionI18nContext(
         <ContextEntryExpressionCell
-          data={[{ entryInfo: { name: entryName, dataType: entryDataType }, entryExpression: emptyExpression }]}
+          data={[
+            {
+              entryInfo: { name: entryName, dataType: entryDataType },
+              entryExpression: emptyExpression,
+              editInfoPopoverLabel: "Edit entry",
+            },
+          ]}
           row={{ index: 0 }}
           column={{ id: "col1" }}
           onRowUpdate={_.identity}
@@ -60,7 +66,13 @@ describe("ContextEntryExpressionCell tests", () => {
     const { container, baseElement } = render(
       usingTestingBoxedExpressionI18nContext(
         <ContextEntryExpressionCell
-          data={[{ entryInfo: { name: value, dataType }, entryExpression: emptyExpression }]}
+          data={[
+            {
+              entryInfo: { name: value, dataType },
+              entryExpression: emptyExpression,
+              editInfoPopoverLabel: "Edit entry",
+            },
+          ]}
           row={{ index: rowIndex }}
           column={{ id: columnId }}
           onRowUpdate={mockedOnRowUpdate}
@@ -91,6 +103,7 @@ describe("ContextEntryExpressionCell tests", () => {
         onUpdatingNameAndDataType: undefined,
         onUpdatingRecursiveExpression: expect.any(Function),
       },
+      editInfoPopoverLabel: "Edit entry",
     });
   });
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextEntryInfo.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextEntryInfo.test.tsx
@@ -31,7 +31,12 @@ describe("ContextEntryInfo tests", () => {
   test("should show a context entry info element with passed name and dataType, when rendering it", () => {
     const { container } = render(
       usingTestingBoxedExpressionI18nContext(
-        <ContextEntryInfo name={name} dataType={dataType} onContextEntryUpdate={_.identity} />
+        <ContextEntryInfo
+          name={name}
+          dataType={dataType}
+          editInfoPopoverLabel="Edit entry"
+          onContextEntryUpdate={_.identity}
+        />
       ).wrapper
     );
 
@@ -48,7 +53,12 @@ describe("ContextEntryInfo tests", () => {
 
     const { container, baseElement } = render(
       usingTestingBoxedExpressionI18nContext(
-        <ContextEntryInfo name={name} dataType={dataType} onContextEntryUpdate={mockedOnContextEntryUpdate} />
+        <ContextEntryInfo
+          name={name}
+          dataType={dataType}
+          editInfoPopoverLabel="Edit entry"
+          onContextEntryUpdate={mockedOnContextEntryUpdate}
+        />
       ).wrapper
     );
 

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextEntryInfoCell.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextEntryInfoCell.test.tsx
@@ -36,7 +36,9 @@ describe("ContextEntryInfoCell tests", () => {
     const { container } = render(
       usingTestingBoxedExpressionI18nContext(
         <ContextEntryInfoCell
-          data={[{ entryInfo: { name, dataType }, entryExpression: emptyExpression }]}
+          data={[
+            { entryInfo: { name, dataType }, entryExpression: emptyExpression, editInfoPopoverLabel: "Edit entry" },
+          ]}
           row={{ index: 0 }}
           column={{ id: "col1" }}
           onRowUpdate={_.identity}
@@ -61,7 +63,9 @@ describe("ContextEntryInfoCell tests", () => {
     const { container, baseElement } = render(
       usingTestingBoxedExpressionI18nContext(
         <ContextEntryInfoCell
-          data={[{ entryInfo: { name, dataType }, entryExpression: emptyExpression }]}
+          data={[
+            { entryInfo: { name, dataType }, entryExpression: emptyExpression, editInfoPopoverLabel: "Edit entry" },
+          ]}
           row={{ index: 0 }}
           column={{ id: "col1" }}
           onRowUpdate={mockedOnRowUpdate}
@@ -83,6 +87,7 @@ describe("ContextEntryInfoCell tests", () => {
         dataType,
       },
       entryExpression: emptyExpression,
+      editInfoPopoverLabel: "Edit entry",
     });
   });
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextExpression.test.tsx
@@ -15,7 +15,13 @@
  */
 
 import { render } from "@testing-library/react";
-import { usingTestingBoxedExpressionI18nContext } from "../test-utils";
+import {
+  checkEntryContent,
+  checkEntryLogicType,
+  checkEntryStyle,
+  contextEntry,
+  usingTestingBoxedExpressionI18nContext,
+} from "../test-utils";
 import { ContextExpression } from "../../../components/ContextExpression";
 import * as React from "react";
 import { DataType, LogicType } from "../../../api";
@@ -101,20 +107,3 @@ describe("ContextExpression tests", () => {
     checkEntryStyle(contextEntry(container, 3), "logic-type-not-present");
   });
 });
-
-function contextEntry(container: Element, index: number): Element | null {
-  return container.querySelector(`.context-expression table tbody tr:nth-of-type(${index})`);
-}
-
-function checkEntryContent(entry: Element | null, entryRecordInfo: { name: string; dataType: string }): void {
-  expect(entry).toContainHTML(entryRecordInfo.name);
-  expect(entry).toContainHTML(entryRecordInfo.dataType);
-}
-
-function checkEntryStyle(entry: Element | null, cssClass: string): void {
-  expect(entry?.querySelector(".entry-expression")?.firstChild).toHaveClass(cssClass);
-}
-
-function checkEntryLogicType(entry: Element | null, cssClass: string): void {
-  expect(entry?.querySelector(".entry-expression")?.firstChild?.firstChild).toHaveClass(cssClass);
-}

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextExpression.test.tsx
@@ -65,6 +65,7 @@ describe("ContextExpression tests", () => {
           dataType: firstDataType,
         },
         entryExpression: firstExpression,
+        editInfoPopoverLabel: "Edit entry",
       },
       {
         entryInfo: {
@@ -72,6 +73,7 @@ describe("ContextExpression tests", () => {
           dataType: secondDataType,
         },
         entryExpression: secondExpression,
+        editInfoPopoverLabel: "Edit entry",
       },
     ];
 

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextExpression.test.tsx
@@ -20,6 +20,11 @@ import { ContextExpression } from "../../../components/ContextExpression";
 import * as React from "react";
 import { DataType, LogicType } from "../../../api";
 
+jest.mock("../../../api", () => ({
+  ...(jest.requireActual("../../../api") as Record<string, unknown>),
+  getHandlerConfiguration: jest.fn(),
+}));
+
 describe("ContextExpression tests", () => {
   const name = "contextName";
   const dataType = DataType.Boolean;

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/InvocationExpression/InvocationExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/InvocationExpression/InvocationExpression.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from "@testing-library/react";
+import { checkEntryContent, contextEntry, usingTestingBoxedExpressionI18nContext } from "../test-utils";
+import { DataType, LogicType } from "../../../api";
+import * as React from "react";
+import { InvocationExpression } from "../../../components/InvocationExpression";
+
+jest.mock("../../../api", () => ({
+  ...(jest.requireActual("../../../api") as Record<string, unknown>),
+  getHandlerConfiguration: jest.fn(),
+}));
+
+describe("InvocationExpression tests", () => {
+  test("should show a table with two levels visible header, with one row and two columns", () => {
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(<InvocationExpression logicType={LogicType.Invocation} />).wrapper
+    );
+
+    expect(container.querySelector(".invocation-expression")).toBeTruthy();
+    expect(container.querySelector(".invocation-expression table")).toBeTruthy();
+    expect(container.querySelector(".invocation-expression table thead")).toBeTruthy();
+    expect(container.querySelectorAll(".invocation-expression table thead tr")).toHaveLength(2);
+    expect(container.querySelectorAll(".invocation-expression table tbody tr")).toHaveLength(1);
+    expect(container.querySelectorAll(".invocation-expression table tbody td.data-cell")).toHaveLength(2);
+  });
+
+  test("should show a table with an input in the header, representing the invoked function", () => {
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(<InvocationExpression logicType={LogicType.Invocation} />).wrapper
+    );
+
+    expect(
+      container.querySelector(".invocation-expression table thead th .function-definition-container")
+    ).toBeTruthy();
+    expect(
+      container.querySelector(".invocation-expression table thead th .function-definition-container")
+    ).toContainHTML(
+      `<input class="function-definition pf-u-text-truncate" type="text" placeholder="Enter function" value="">`
+    );
+  });
+
+  test("should display the value of the passed invoked function", () => {
+    const invokedFunction = "Math.max";
+
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <InvocationExpression logicType={LogicType.Invocation} invokedFunction={invokedFunction} />
+      ).wrapper
+    );
+
+    expect((container.querySelector(".invocation-expression .function-definition") as HTMLInputElement).value).toBe(
+      invokedFunction
+    );
+  });
+
+  test("should display a row in the table body, for each given binding entries", () => {
+    const firstEntryName = "param1";
+    const firstEntryDataType = DataType.Boolean;
+    const firstEntry = { entryInfo: { name: firstEntryName, dataType: firstEntryDataType }, entryExpression: {} };
+    const secondEntryName = "param2";
+    const secondEntryDataType = DataType.Any;
+    const secondEntry = { entryInfo: { name: secondEntryName, dataType: secondEntryDataType }, entryExpression: {} };
+    const bindingEntries = [firstEntry, secondEntry];
+
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <InvocationExpression logicType={LogicType.Invocation} bindingEntries={bindingEntries} />
+      ).wrapper
+    );
+
+    expect(container.querySelector(".invocation-expression")).toBeTruthy();
+    expect(container.querySelectorAll(".invocation-expression table tbody tr")).toHaveLength(2);
+    checkEntryContent(contextEntry(container, 1), firstEntry.entryInfo);
+    checkEntryContent(contextEntry(container, 2), secondEntry.entryInfo);
+  });
+});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/InvocationExpression/InvocationExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/InvocationExpression/InvocationExpression.test.tsx
@@ -71,10 +71,18 @@ describe("InvocationExpression tests", () => {
   test("should display a row in the table body, for each given binding entries", () => {
     const firstEntryName = "param1";
     const firstEntryDataType = DataType.Boolean;
-    const firstEntry = { entryInfo: { name: firstEntryName, dataType: firstEntryDataType }, entryExpression: {} };
+    const firstEntry = {
+      entryInfo: { name: firstEntryName, dataType: firstEntryDataType },
+      entryExpression: {},
+      editInfoPopoverLabel: "Edit parameter",
+    };
     const secondEntryName = "param2";
     const secondEntryDataType = DataType.Any;
-    const secondEntry = { entryInfo: { name: secondEntryName, dataType: secondEntryDataType }, entryExpression: {} };
+    const secondEntry = {
+      entryInfo: { name: secondEntryName, dataType: secondEntryDataType },
+      entryExpression: {},
+      editInfoPopoverLabel: "Edit parameter",
+    };
     const bindingEntries = [firstEntry, secondEntry];
 
     const { container } = render(

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/LogicTypeSelector/LogicTypeSelector.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/LogicTypeSelector/LogicTypeSelector.test.tsx
@@ -69,7 +69,7 @@ describe("LogicTypeSelector tests", () => {
 
 describe("Logic type selection", () => {
   test("should show the pre-selection, when logic type prop is passed", () => {
-    const expression = { name: "Test", logicType: LogicType.Invocation, dataType: DataType.Undefined };
+    const expression = { name: "Test", logicType: LogicType.List, dataType: DataType.Undefined };
 
     const { baseElement } = render(
       usingTestingBoxedExpressionI18nContext(

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Table/Table.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Table/Table.test.tsx
@@ -445,7 +445,7 @@ describe("Table tests", () => {
       await openContextMenu(container.querySelector(expressionCell(0, 0))!);
       await selectMenuEntryIfNotDisabled(baseElement, "Delete");
 
-      expect(mockedOnColumnUpdate).toHaveBeenCalledWith([firstColumn, secondColumn]);
+      expect(mockedOnColumnUpdate).toHaveBeenCalledTimes(0);
     });
 
     test("should trigger onRowsUpdate, when inserting a new row above", async () => {

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Table/Table.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Table/Table.test.tsx
@@ -55,6 +55,13 @@ const expressionTableHandlerMenuEntry = (menuEntry: string) => {
   return "[data-ouia-component-id='expression-table-handler-menu-" + menuEntry + "']";
 };
 
+const assertHeaderCell = (container: Element, expectedCells: number, content: string) => {
+  expect(container.querySelector(".table-component table thead")).toBeTruthy();
+  expect(container.querySelector(".table-component table thead tr")).toBeTruthy();
+  expect(container.querySelectorAll(EXPRESSION_COLUMN_HEADER).length).toBe(expectedCells);
+  expect(container.querySelectorAll(EXPRESSION_COLUMN_HEADER)[expectedCells - 1].innerHTML).toContain(content);
+};
+
 describe("Table tests", () => {
   const columnName = "column-1";
   const handlerConfiguration: TableHandlerConfiguration = [];
@@ -91,13 +98,10 @@ describe("Table tests", () => {
         ).wrapper
       );
 
-      expect(container.querySelector(".table-component table thead")).toBeTruthy();
-      expect(container.querySelector(".table-component table thead tr")).toBeTruthy();
-      expect(container.querySelectorAll(EXPRESSION_COLUMN_HEADER).length).toBe(1);
-      expect(container.querySelectorAll(EXPRESSION_COLUMN_HEADER)[0].innerHTML).toContain("#");
+      assertHeaderCell(container, 1, "#");
     });
 
-    test("should show a table head with one configured column", () => {
+    test("should show a table head with one configured column, rendering its label", () => {
       const { container } = render(
         usingTestingBoxedExpressionI18nContext(
           <Table
@@ -111,10 +115,33 @@ describe("Table tests", () => {
         ).wrapper
       );
 
-      expect(container.querySelector(".table-component table thead")).toBeTruthy();
-      expect(container.querySelector(".table-component table thead tr")).toBeTruthy();
-      expect(container.querySelectorAll(EXPRESSION_COLUMN_HEADER).length).toBe(2);
-      expect(container.querySelectorAll(EXPRESSION_COLUMN_HEADER)[1].innerHTML).toContain(columnName);
+      assertHeaderCell(container, 2, columnName);
+    });
+
+    test("should show a table head with one configured column, rendering its custom element", () => {
+      const customElementContent = "Custom Element";
+      const headerCellElement = <div>`${customElementContent}`</div>;
+
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <Table
+            columnPrefix="column-"
+            columns={[
+              {
+                accessor: columnName,
+                headerCellElement,
+                dataType: DataType.Undefined,
+              } as ColumnInstance,
+            ]}
+            rows={[]}
+            onColumnsUpdate={_.identity}
+            onRowsUpdate={_.identity}
+            handlerConfiguration={handlerConfiguration}
+          />
+        ).wrapper
+      );
+
+      assertHeaderCell(container, 2, customElementContent);
     });
 
     test("should show a table body with no rows", () => {

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/test-utils.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/test-utils.tsx
@@ -82,6 +82,22 @@ export async function updateElementViaPopover(
   fireEvent.blur(inputElement);
 }
 
+export const contextEntry = (container: Element, index: number): Element | null =>
+  container.querySelector(`table tbody tr:nth-of-type(${index})`);
+
+export const checkEntryContent = (entry: Element | null, entryRecordInfo: { name: string; dataType: string }): void => {
+  expect(entry).toContainHTML(entryRecordInfo.name);
+  expect(entry).toContainHTML(entryRecordInfo.dataType);
+};
+
+export const checkEntryStyle = (entry: Element | null, cssClass: string): void => {
+  expect(entry?.querySelector(".entry-expression")?.firstChild).toHaveClass(cssClass);
+};
+
+export const checkEntryLogicType = (entry: Element | null, cssClass: string): void => {
+  expect(entry?.querySelector(".entry-expression")?.firstChild?.firstChild).toHaveClass(cssClass);
+};
+
 beforeEach(() => {
   resetId();
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/api/BoxedExpressionEditor.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/BoxedExpressionEditor.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import { ContextProps, ExpressionProps, ListProps, LiteralExpressionProps, RelationProps } from "./ExpressionProps";
+import {
+  ContextProps,
+  ExpressionProps,
+  InvocationProps,
+  ListProps,
+  LiteralExpressionProps,
+  RelationProps,
+} from "./ExpressionProps";
 
 export {};
 
@@ -28,6 +35,7 @@ declare global {
       broadcastRelationExpressionDefinition: (definition: RelationProps) => void;
       broadcastContextExpressionDefinition: (definition: ContextProps) => void;
       broadcastListExpressionDefinition: (definition: ListProps) => void;
+      broadcastInvocationExpressionDefinition: (definition: InvocationProps) => void;
     };
   }
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ContextEntry.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ContextEntry.ts
@@ -30,6 +30,8 @@ export interface ContextEntryRecord {
   };
   /** Entry expression */
   entryExpression: ExpressionProps;
+  /** Label used for the popover triggered when editing info section */
+  editInfoPopoverLabel: string;
   /** Callback to be invoked on expression resetting */
   onExpressionResetting?: () => void;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ContextEntry.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ContextEntry.ts
@@ -16,6 +16,10 @@
 
 import { DataType } from "./DataType";
 import { ExpressionProps } from "./ExpressionProps";
+import * as _ from "lodash";
+import { DataRecord, Row } from "react-table";
+import { TableHandlerConfiguration, TableOperation } from "./Table";
+import { BoxedExpressionEditorI18n } from "../i18n";
 
 export interface ContextEntryRecord {
   entryInfo: {
@@ -31,3 +35,40 @@ export interface ContextEntryRecord {
 }
 
 export type ContextEntries = ContextEntryRecord[];
+
+export const DEFAULT_ENTRY_INFO_MIN_WIDTH = 150;
+export const DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH = 370;
+
+export const getHandlerConfiguration = (
+  i18n: BoxedExpressionEditorI18n,
+  groupName: string
+): TableHandlerConfiguration => [
+  {
+    group: groupName,
+    items: [
+      { name: i18n.rowOperations.insertAbove, type: TableOperation.RowInsertAbove },
+      { name: i18n.rowOperations.insertBelow, type: TableOperation.RowInsertBelow },
+      { name: i18n.rowOperations.delete, type: TableOperation.RowDelete },
+      { name: i18n.rowOperations.clear, type: TableOperation.RowClear },
+    ],
+  },
+];
+
+export const generateNextAvailableEntryName = (
+  contextEntries: ContextEntries,
+  namePrefix: string,
+  lastIndex: number = contextEntries.length
+): string => {
+  const candidateName = `${namePrefix}-${lastIndex}`;
+  const entryWithCandidateName = _.find(contextEntries, { entryInfo: { name: candidateName } });
+  return entryWithCandidateName
+    ? generateNextAvailableEntryName(contextEntries, namePrefix, lastIndex + 1)
+    : candidateName;
+};
+
+export const getEntryKey = (row: Row): string => (row.original as ContextEntryRecord).entryInfo.name;
+
+export const resetEntry = (row: DataRecord): DataRecord => ({
+  entryInfo: row.entryInfo,
+  entryExpression: { uid: (row.entryExpression as ExpressionProps).uid },
+});

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -95,3 +95,16 @@ export interface ListProps extends ExpressionProps {
   /** Optional width for this list expression */
   width?: number;
 }
+
+export interface InvocationProps extends ExpressionProps {
+  /** Logic type must be Invocation */
+  logicType: LogicType.Invocation;
+  /** Function to be invoked */
+  invokedFunction?: string;
+  /** Collection of parameters used to invoke the function */
+  bindingEntries?: ContextEntries;
+  /** Entry info width */
+  entryInfoWidth?: number;
+  /** Entry expression width */
+  entryExpressionWidth?: number;
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/api/Table.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/Table.ts
@@ -19,7 +19,8 @@ import { DataType } from "./DataType";
 /** Possible status for the visibility of the Table's Header */
 export enum TableHeaderVisibility {
   Full,
-  OnlyLastLevel,
+  LastLevel,
+  SecondToLastLevel,
   None,
 }
 

--- a/kie-wb-common-react/boxed-expression-editor/src/api/Table.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/Table.ts
@@ -47,6 +47,8 @@ export interface TableProps {
   headerVisibility?: TableHeaderVisibility;
   /** Number of levels in the header, 0-based */
   headerLevels?: number;
+  /** True, for skipping the creation in the DOM of the last defined header group */
+  skipLastHeaderGroup?: boolean;
   /** Custom function for getting row key prop, and avoid using the row index */
   getRowKey?: (row: ReactTableRow) => string;
   /** Custom function for getting column key prop, and avoid using the column index */

--- a/kie-wb-common-react/boxed-expression-editor/src/api/Table.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/Table.ts
@@ -39,8 +39,6 @@ export interface TableProps {
   onColumnsUpdate?: (columns: ReactTableColumn[]) => void;
   /** Function to be executed when one or more rows are modified */
   onRowsUpdate?: (rows: DataRecord[]) => void;
-  /** Function to be executed when a single row gets modified */
-  onSingleRowUpdate?: (rowIndex: number, row: DataRecord) => void;
   /** Function to be executed when adding a new row to the table */
   onRowAdding?: () => DataRecord;
   /** Custom configuration for the table handler */

--- a/kie-wb-common-react/boxed-expression-editor/src/api/Table.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/Table.ts
@@ -15,6 +15,47 @@
  */
 
 import { DataType } from "./DataType";
+import * as React from "react";
+import { Column as ReactTableColumn, DataRecord, Row as ReactTableRow } from "react-table";
+
+export interface TableProps {
+  /** Table identifier, useful for nested structures */
+  tableId?: string;
+  /** Optional children element to be appended below the table content */
+  children?: React.ReactElement[];
+  /** The prefix to be used for the column name */
+  columnPrefix?: string;
+  /** Optional label to be used for the edit popover that appears when clicking on column header */
+  editColumnLabel?: string;
+  /** For each column there is a default component to be used to render the related cell */
+  defaultCell?: {
+    [columnName: string]: React.FunctionComponent<CellProps>;
+  };
+  /** Table's columns */
+  columns: ReactTableColumn[];
+  /** Table's cells */
+  rows: DataRecord[];
+  /** Function to be executed when columns are modified */
+  onColumnsUpdate?: (columns: ReactTableColumn[]) => void;
+  /** Function to be executed when one or more rows are modified */
+  onRowsUpdate?: (rows: DataRecord[]) => void;
+  /** Function to be executed when a single row gets modified */
+  onSingleRowUpdate?: (rowIndex: number, row: DataRecord) => void;
+  /** Function to be executed when adding a new row to the table */
+  onRowAdding?: () => DataRecord;
+  /** Custom configuration for the table handler */
+  handlerConfiguration: TableHandlerConfiguration;
+  /** The way in which the header will be rendered */
+  headerVisibility?: TableHeaderVisibility;
+  /** Number of levels in the header, 0-based */
+  headerLevels?: number;
+  /** Custom function for getting row key prop, and avoid using the row index */
+  getRowKey?: (row: ReactTableRow) => string;
+  /** Custom function for getting column key prop, and avoid using the column index */
+  getColumnKey?: (column: ReactTableColumn) => string;
+  /** Custom function called for manually resetting a row */
+  resetRowCustomFunction?: (row: DataRecord) => DataRecord;
+}
 
 /** Possible status for the visibility of the Table's Header */
 export enum TableHeaderVisibility {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextEntryInfo.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextEntryInfo.css
@@ -14,24 +14,21 @@
  * limitations under the License.
  */
 
-.context-expression .entry-info {
+.expression-container .entry-info {
   width: 100%;
 }
 
-.context-expression .entry-info .entry-definition {
+.expression-container .entry-info .entry-definition {
   cursor: pointer;
   padding: 0.25em;
 }
 
-.context-expression .entry-info .entry-definition .entry-name {
+.expression-container .entry-info .entry-definition .entry-name {
   white-space: nowrap;
 }
 
-.context-expression .entry-info .entry-definition .entry-data-type {
+.expression-container .entry-info .entry-definition .entry-data-type {
+  white-space: nowrap;
   font-style: italic;
   font-size: smaller;
-}
-
-.context-expression .context-expression table th .header-cell {
-  height: 24px;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextEntryInfo.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextEntryInfo.tsx
@@ -18,7 +18,6 @@ import "./ContextEntryInfo.css";
 import * as React from "react";
 import { useCallback, useEffect, useState } from "react";
 import { EditExpressionMenu } from "../EditExpressionMenu";
-import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { DataType } from "../../api";
 
 export interface ContextEntryInfoProps {
@@ -28,15 +27,16 @@ export interface ContextEntryInfoProps {
   dataType: DataType;
   /** Callback to be executed when name or dataType get updated */
   onContextEntryUpdate: (name: string, dataType: DataType) => void;
+  /** Label used for the popover triggered when editing info section */
+  editInfoPopoverLabel: string;
 }
 
 export const ContextEntryInfo: React.FunctionComponent<ContextEntryInfoProps> = ({
   name,
   dataType,
   onContextEntryUpdate,
+  editInfoPopoverLabel,
 }) => {
-  const { i18n } = useBoxedExpressionEditorI18n();
-
   const [entryName, setEntryName] = useState(name);
 
   const [entryDataType, setEntryDataType] = useState(dataType);
@@ -61,7 +61,7 @@ export const ContextEntryInfo: React.FunctionComponent<ContextEntryInfoProps> = 
   return (
     <div className="entry-info">
       <EditExpressionMenu
-        title={i18n.editContextEntry}
+        title={editInfoPopoverLabel}
         selectedExpressionName={entryName}
         selectedDataType={entryDataType}
         onExpressionUpdate={onEntryNameOrDataTypeUpdate}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextEntryInfoCell.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextEntryInfoCell.tsx
@@ -51,6 +51,7 @@ export const ContextEntryInfoCell: React.FunctionComponent<ContextEntryInfoCellP
         name={entryInfo.name}
         dataType={entryInfo.dataType}
         onContextEntryUpdate={onContextEntryUpdate}
+        editInfoPopoverLabel={contextEntry.editInfoPopoverLabel}
       />
     </div>
   );

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.css
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-.context-expression {
+.expression-container .context-expression {
   width: 100%;
 }
 
-.context-expression .context-result {
+.expression-container .context-expression .context-result {
   font-style: italic;
   color: gray;
 }
 
-.context-expression .context-entry-info-cell,
-.context-expression .context-result {
+.expression-container .context-entry-info-cell,
+.expression-container .context-expression .context-result {
   height: 100%;
   display: flex;
   align-items: center;

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
@@ -93,6 +93,7 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
           dataType: DEFAULT_CONTEXT_ENTRY_DATA_TYPE,
         },
         entryExpression: {},
+        editInfoPopoverLabel: i18n.editContextEntry,
       } as DataRecord,
     ]
   );
@@ -121,8 +122,9 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
         dataType: DataType.Undefined,
       },
       entryExpression: {},
+      editInfoPopoverLabel: i18n.editContextEntry,
     }),
-    [rows]
+    [i18n.editContextEntry, rows]
   );
 
   const getHeaderVisibility = useCallback(() => {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
@@ -148,7 +148,7 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
   const contextTableGetRowKey = useCallback((row: Row) => (row.original as ContextEntryRecord).entryInfo.name, []);
 
   const getHeaderVisibility = useCallback(() => {
-    return isHeadless ? TableHeaderVisibility.OnlyLastLevel : TableHeaderVisibility.Full;
+    return isHeadless ? TableHeaderVisibility.LastLevel : TableHeaderVisibility.Full;
   }, [isHeadless]);
 
   const resetRowCustomFunction = useCallback((row: DataRecord) => {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
@@ -67,10 +67,6 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
     },
   ];
 
-  const onExpressionResetting = useCallback(() => {
-    setExpressionWidth(DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH);
-  }, []);
-
   const [resultExpression, setResultExpression] = useState(result);
   const [infoWidth, setInfoWidth] = useState(entryInfoWidth);
   const [expressionWidth, setExpressionWidth] = useState(entryExpressionWidth);
@@ -108,7 +104,6 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
           dataType: DEFAULT_CONTEXT_ENTRY_DATA_TYPE,
         },
         entryExpression: {},
-        onExpressionResetting,
       } as DataRecord,
     ]
   );
@@ -146,9 +141,8 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
         dataType: DataType.Undefined,
       },
       entryExpression: {},
-      onExpressionResetting,
     }),
-    [generateNextAvailableEntryName, onExpressionResetting, rows.length]
+    [generateNextAvailableEntryName, rows.length]
   );
 
   const contextTableGetRowKey = useCallback((row: Row) => (row.original as ContextEntryRecord).entryInfo.name, []);
@@ -182,7 +176,7 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
     <div className={`context-expression ${uid}`}>
       <Table
         tableId={uid}
-        headerHasMultipleLevels={true}
+        headerLevels={1}
         headerVisibility={getHeaderVisibility()}
         defaultCell={{ entryInfo: ContextEntryInfoCell, entryExpression: ContextEntryExpressionCell }}
         columns={columns}
@@ -195,11 +189,7 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
         resetRowCustomFunction={resetRowCustomFunction}
       >
         <div className="context-result">{`<result>`}</div>
-        <ContextEntryExpression
-          expression={resultExpression}
-          onUpdatingRecursiveExpression={setResultExpression}
-          onExpressionResetting={onExpressionResetting}
-        />
+        <ContextEntryExpression expression={resultExpression} onUpdatingRecursiveExpression={setResultExpression} />
       </Table>
     </div>
   );

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.css
@@ -22,14 +22,6 @@
   height: 100%;
 }
 
-.expression-container .invocation-expression > .table-component > table > thead > tr:nth-child(3) {
-  /**
-    Hiding last row in the header since it is useless for the Invocation expression
-    Using !important because of the inline style
-  */
-  display: none !important;
-}
-
 .expression-container .invocation-expression .function-definition-container {
   padding-right: 0.75em;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.css
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.expression-container .invocation-expression .function-definition-container,
+.expression-container .invocation-expression .function-definition-container .function-definition,
+.expression-container .invocation-expression > .table-component > table > thead > tr:last-of-type > th:last-of-type > .header-cell > .header-cell-info {
+  width: 100%;
+  height: 100%;
+}
+
+.expression-container .invocation-expression .function-definition-container {
+  padding-right: 0.75em;
+}
+
+.expression-container .invocation-expression .function-definition-container .function-definition {
+  border: none;
+  background-color: #DEF3FF;
+  font-family: monospace;
+  padding: 0.25em;
+}
+
+.expression-container .invocation-expression .function-definition-container .function-definition::placeholder {
+  font-style: italic;
+  text-align: center;
+  font-family: var(--pf-global--FontFamily--sans-serif);
+}
+
+.expression-container .invocation-expression .function-definition-container .function-definition:focus {
+  background-color: white;
+  font-family: inherit;
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.css
@@ -17,21 +17,17 @@
 .expression-container .invocation-expression .function-definition-container,
 .expression-container .invocation-expression .function-definition-container .function-definition,
 /** Increasing width and height for the .header-cell-info which contains .function-definition-container */
-.expression-container .invocation-expression > .table-component > table > thead > tr:nth-of-type(2) > th:last-of-type > .header-cell > .header-cell-info {
+.expression-container .invocation-expression > .table-component > table > thead > tr > th:last-of-type > .header-cell > .header-cell-info {
   width: 100%;
   height: 100%;
 }
 
-.expression-container .invocation-expression > .table-component > table > thead > tr:last-of-type {
+.expression-container .invocation-expression > .table-component > table > thead > tr:nth-child(3) {
+  /**
+    Hiding last row in the header since it is useless for the Invocation expression
+    Using !important because of the inline style
+  */
   display: none !important;
-}
-
-.expression-container .invocation-expression > .table-component > table > tbody > tr > td:nth-child(2) {
-  width: fit-content !important;
-}
-
-.expression-container .invocation-expression > .table-component > table > tbody > tr > td:nth-child(3) {
-  width: 100% !important;
 }
 
 .expression-container .invocation-expression .function-definition-container {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.css
@@ -16,9 +16,22 @@
 
 .expression-container .invocation-expression .function-definition-container,
 .expression-container .invocation-expression .function-definition-container .function-definition,
-.expression-container .invocation-expression > .table-component > table > thead > tr:last-of-type > th:last-of-type > .header-cell > .header-cell-info {
+/** Increasing width and height for the .header-cell-info which contains .function-definition-container */
+.expression-container .invocation-expression > .table-component > table > thead > tr:nth-of-type(2) > th:last-of-type > .header-cell > .header-cell-info {
   width: 100%;
   height: 100%;
+}
+
+.expression-container .invocation-expression > .table-component > table > thead > tr:last-of-type {
+  display: none !important;
+}
+
+.expression-container .invocation-expression > .table-component > table > tbody > tr > td:nth-child(2) {
+  width: fit-content !important;
+}
+
+.expression-container .invocation-expression > .table-component > table > tbody > tr > td:nth-child(3) {
+  width: 100% !important;
 }
 
 .expression-container .invocation-expression .function-definition-container {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
@@ -30,5 +30,5 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
   onUpdatingRecursiveExpression,
   uid,
 }: InvocationProps) => {
-  return <div>Invocation</div>;
+  return <div className={`invocation-expression ${uid}`}></div>;
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
@@ -16,10 +16,12 @@
 
 import "./InvocationExpression.css";
 import * as React from "react";
-import { InvocationProps, TableHandlerConfiguration, TableOperation } from "../../api";
+import { useState } from "react";
+import { DataType, InvocationProps, TableHandlerConfiguration, TableOperation } from "../../api";
 import { Table } from "../Table";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
-import { ColumnInstance } from "react-table";
+import { ColumnInstance, DataRecord } from "react-table";
+import { ContextEntryExpressionCell, ContextEntryInfoCell } from "../ContextExpression";
 
 export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
   bindingEntries,
@@ -48,10 +50,24 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
     },
   ];
 
+  const [rows] = useState(
+    bindingEntries || [
+      {
+        entryInfo: {
+          name: "p-1",
+          dataType: DataType.Undefined,
+        },
+        entryExpression: {},
+      } as DataRecord,
+    ]
+  );
+
   return (
     <div className={`invocation-expression ${uid}`}>
       <Table
         tableId={uid}
+        headerLevels={2}
+        defaultCell={{ entryInfo: ContextEntryInfoCell, entryExpression: ContextEntryExpressionCell }}
         columns={
           [
             {
@@ -60,13 +76,6 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
               dataType,
               disableHandlerOnHeader: true,
               columns: [
-                {
-                  label: "Parameter",
-                  accessor: "entryInfo",
-                  disableHandlerOnHeader: true,
-                  width: 150,
-                  minWidth: 150,
-                },
                 {
                   headerCellElement: (
                     <div className="function-definition-container">
@@ -77,16 +86,29 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
                       />
                     </div>
                   ),
-                  accessor: "entryExpression",
+                  accessor: "functionDefinition",
+                  canResize: false,
                   disableHandlerOnHeader: true,
-                  width: 370,
-                  minWidth: 370,
+                  columns: [
+                    {
+                      accessor: "entryInfo",
+                      disableHandlerOnHeader: true,
+                      minWidth: 100,
+                      maxWidth: 100,
+                    },
+                    {
+                      accessor: "entryExpression",
+                      disableHandlerOnHeader: true,
+                      minWidth: 225,
+                      width: 225,
+                    },
+                  ],
                 },
               ] as ColumnInstance[],
             },
           ] as ColumnInstance[]
         }
-        rows={[{}]}
+        rows={rows as DataRecord[]}
         handlerConfiguration={handlerConfiguration}
       />
     </div>

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import { InvocationProps } from "../../api";
+
+export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
+  bindingEntries,
+  dataType,
+  entryExpressionWidth,
+  entryInfoWidth,
+  invokedFunction,
+  isHeadless,
+  logicType,
+  name,
+  onUpdatingNameAndDataType,
+  onUpdatingRecursiveExpression,
+  uid,
+}: InvocationProps) => {
+  return <div>Invocation</div>;
+};

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
@@ -61,6 +61,7 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
           dataType: DEFAULT_PARAMETER_DATA_TYPE,
         },
         entryExpression: {},
+        editInfoPopoverLabel: i18n.editParameter,
       } as DataRecord,
     ]
   );
@@ -165,8 +166,9 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
         dataType: DEFAULT_PARAMETER_DATA_TYPE,
       },
       entryExpression: {},
+      editInfoPopoverLabel: i18n.editParameter,
     }),
-    [rows]
+    [i18n.editParameter, rows]
   );
 
   const getHeaderVisibility = useCallback(() => {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
+import "./InvocationExpression.css";
 import * as React from "react";
-import { InvocationProps } from "../../api";
+import { InvocationProps, TableHandlerConfiguration, TableOperation } from "../../api";
+import { Table } from "../Table";
+import { useBoxedExpressionEditorI18n } from "../../i18n";
+import { ColumnInstance } from "react-table";
 
 export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
   bindingEntries,
@@ -30,5 +34,61 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
   onUpdatingRecursiveExpression,
   uid,
 }: InvocationProps) => {
-  return <div className={`invocation-expression ${uid}`}></div>;
+  const { i18n } = useBoxedExpressionEditorI18n();
+
+  const handlerConfiguration: TableHandlerConfiguration = [
+    {
+      group: "Parameters",
+      items: [
+        { name: i18n.rowOperations.insertAbove, type: TableOperation.RowInsertAbove },
+        { name: i18n.rowOperations.insertBelow, type: TableOperation.RowInsertBelow },
+        { name: i18n.rowOperations.delete, type: TableOperation.RowDelete },
+        { name: i18n.rowOperations.clear, type: TableOperation.RowClear },
+      ],
+    },
+  ];
+
+  return (
+    <div className={`invocation-expression ${uid}`}>
+      <Table
+        tableId={uid}
+        columns={
+          [
+            {
+              label: name,
+              accessor: name,
+              dataType,
+              disableHandlerOnHeader: true,
+              columns: [
+                {
+                  label: "Parameter",
+                  accessor: "entryInfo",
+                  disableHandlerOnHeader: true,
+                  width: 150,
+                  minWidth: 150,
+                },
+                {
+                  headerCellElement: (
+                    <div className="function-definition-container">
+                      <input
+                        className="function-definition pf-u-text-truncate"
+                        type="text"
+                        placeholder="Enter function"
+                      />
+                    </div>
+                  ),
+                  accessor: "entryExpression",
+                  disableHandlerOnHeader: true,
+                  width: 370,
+                  minWidth: 370,
+                },
+              ] as ColumnInstance[],
+            },
+          ] as ColumnInstance[]
+        }
+        rows={[{}]}
+        handlerConfiguration={handlerConfiguration}
+      />
+    </div>
+  );
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
@@ -16,22 +16,25 @@
 
 import "./InvocationExpression.css";
 import * as React from "react";
-import { useState } from "react";
-import { DataType, InvocationProps, TableHandlerConfiguration, TableOperation } from "../../api";
+import { useCallback, useState } from "react";
+import { DataType, InvocationProps, TableHandlerConfiguration, TableHeaderVisibility, TableOperation } from "../../api";
 import { Table } from "../Table";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { ColumnInstance, DataRecord } from "react-table";
 import { ContextEntryExpressionCell, ContextEntryInfoCell } from "../ContextExpression";
 
+const DEFAULT_PARAMETER_NAME = "p-1";
+const DEFAULT_PARAMETER_DATA_TYPE = DataType.Undefined;
+
 export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
   bindingEntries,
-  dataType,
+  dataType = DEFAULT_PARAMETER_DATA_TYPE,
   entryExpressionWidth,
   entryInfoWidth,
   invokedFunction,
   isHeadless,
   logicType,
-  name,
+  name = DEFAULT_PARAMETER_NAME,
   onUpdatingNameAndDataType,
   onUpdatingRecursiveExpression,
   uid,
@@ -54,13 +57,28 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
     bindingEntries || [
       {
         entryInfo: {
-          name: "p-1",
-          dataType: DataType.Undefined,
+          name: DEFAULT_PARAMETER_NAME,
+          dataType: DEFAULT_PARAMETER_DATA_TYPE,
         },
         entryExpression: {},
       } as DataRecord,
     ]
   );
+
+  const onRowAdding = useCallback(
+    () => ({
+      entryInfo: {
+        name: "p-2",
+        dataType: DEFAULT_PARAMETER_DATA_TYPE,
+      },
+      entryExpression: {},
+    }),
+    []
+  );
+
+  const getHeaderVisibility = useCallback(() => {
+    return isHeadless ? TableHeaderVisibility.SecondToLastLevel : TableHeaderVisibility.Full;
+  }, [isHeadless]);
 
   return (
     <div className={`invocation-expression ${uid}`}>
@@ -68,6 +86,8 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
         tableId={uid}
         headerLevels={2}
         defaultCell={{ entryInfo: ContextEntryInfoCell, entryExpression: ContextEntryExpressionCell }}
+        onRowAdding={onRowAdding}
+        headerVisibility={getHeaderVisibility()}
         columns={
           [
             {
@@ -87,18 +107,19 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
                     </div>
                   ),
                   accessor: "functionDefinition",
-                  canResize: false,
                   disableHandlerOnHeader: true,
                   columns: [
                     {
                       accessor: "entryInfo",
                       disableHandlerOnHeader: true,
-                      minWidth: 100,
-                      maxWidth: 100,
+                      canResizeOnCell: true,
+                      minWidth: 130,
+                      width: 130,
                     },
                     {
                       accessor: "entryExpression",
                       disableHandlerOnHeader: true,
+                      canResizeOnCell: true,
                       minWidth: 225,
                       width: 225,
                     },

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/index.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./InvocationExpression";

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
@@ -28,6 +28,10 @@
   bottom: 0;
 }
 
+.expression-container .literal-expression {
+  width: 100%;
+}
+
 .literal-expression .literal-expression-header .expression-info {
   cursor: pointer;
   display: flex;
@@ -54,6 +58,7 @@
 
 .literal-expression .literal-expression-body {
   height: 4em;
+  width: 100%;
 }
 
 .literal-expression .literal-expression-body textarea {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.tsx
@@ -22,6 +22,7 @@ import {
   DataType,
   DecisionTableProps,
   ExpressionProps,
+  InvocationProps,
   ListProps,
   LiteralExpressionProps,
   LogicType,
@@ -40,6 +41,7 @@ import nextId from "react-id-generator";
 import { BoxedExpressionGlobalContext } from "../../context";
 import { DecisionTableExpression } from "../DecisionTableExpression";
 import { ListExpression } from "../ListExpression";
+import { InvocationExpression } from "../InvocationExpression";
 
 export interface LogicTypeSelectorProps {
   /** Expression properties */
@@ -104,10 +106,11 @@ export const LogicTypeSelector: React.FunctionComponent<LogicTypeSelectorProps> 
         return <ContextExpression {...(expression as ContextProps)} />;
       case LogicType.DecisionTable:
         return <DecisionTableExpression {...(expression as DecisionTableProps)} />;
-      case LogicType.Function:
       case LogicType.Invocation:
+        return <InvocationExpression {...(expression as InvocationProps)} />;
       case LogicType.List:
         return <ListExpression {...(expression as ListProps)} />;
+      case LogicType.Function:
       default:
         return expression.logicType;
     }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/RelationExpression/RelationExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/RelationExpression/RelationExpression.tsx
@@ -78,12 +78,12 @@ export const RelationExpression: React.FunctionComponent<RelationProps> = (relat
             ...(column.width ? { width: column.width } : {}),
           } as Column)
       ),
-    [tableColumns]
+    []
   );
 
   const convertRowsForTheTable = useCallback(
     () =>
-      _.map(tableRows, (row) =>
+      _.map(tableRows.current, (row) =>
         _.reduce(
           tableColumns.current,
           (tableRow: DataRecord, column, columnIndex) => {
@@ -93,7 +93,7 @@ export const RelationExpression: React.FunctionComponent<RelationProps> = (relat
           {}
         )
       ),
-    [tableColumns, tableRows]
+    []
   );
 
   const onSavingRows = useCallback(

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/Resizer.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/Resizer.tsx
@@ -28,6 +28,12 @@ export interface ResizerProps {
   children?: React.ReactElement;
 }
 
+export const DRAWER_SPLITTER_ELEMENT = (
+  <div className="pf-c-drawer__splitter pf-m-vertical">
+    <div className="pf-c-drawer__splitter-handle" />
+  </div>
+);
+
 export const Resizer: React.FunctionComponent<ResizerProps> = ({
   children,
   height,
@@ -38,16 +44,7 @@ export const Resizer: React.FunctionComponent<ResizerProps> = ({
 }) => {
   const targetHeight = height === "100%" ? 0 : height;
 
-  const resizerHandler = useMemo(
-    () => (
-      <div className="pf-c-drawer">
-        <div className="pf-c-drawer__splitter pf-m-vertical">
-          <div className="pf-c-drawer__splitter-handle" />
-        </div>
-      </div>
-    ),
-    []
-  );
+  const resizerHandler = useMemo(() => <div className="pf-c-drawer">{DRAWER_SPLITTER_ELEMENT}</div>, []);
 
   const onResizeStop = useCallback((e, data) => onHorizontalResizeStop(data.size.width), [onHorizontalResizeStop]);
 

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.css
@@ -124,6 +124,10 @@
   overflow-y: hidden;
 }
 
+.expression-container .table-component table tbody td.data-cell.has-resizer .logic-type-selector.logic-type-selected {
+  padding: .5em 1.2em .5em .5em;
+}
+
 /** Drawer for resizing columns */
 
 .expression-container .table-component table .pf-c-drawer__splitter {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.css
@@ -28,6 +28,8 @@
   width: 100%;
 }
 
+/** Table Header rules */
+
 .expression-container .table-component table th {
   min-height: 55px;
   position: relative;
@@ -84,6 +86,8 @@
   border: 1px solid #CCC;
 }
 
+/** Table Body rules */
+
 .expression-container .table-component table tbody tr {
   display: flex;
   border: 0;
@@ -120,6 +124,8 @@
   overflow-y: hidden;
 }
 
+/** Drawer for resizing columns */
+
 .expression-container .table-component table .pf-c-drawer__splitter {
   background-color: inherit;
 }
@@ -143,6 +149,17 @@
   background-color: lightgray;
 }
 
+.expression-container .table-component table .pf-c-drawer.drawer-on-body > .pf-c-drawer__splitter > .pf-c-drawer__splitter-handle {
+  z-index: 1;
+}
+
+.expression-container .table-component table .pf-c-drawer.drawer-on-body > .pf-c-drawer__splitter::after {
+  border-width: 1px;
+  background-color: white;
+}
+
+/** Text-area used as a cell */
+
 .expression-container .table-component table tbody td textarea {
   padding: 0.125em;
   margin: 0;
@@ -152,11 +169,15 @@
   resize: none;
 }
 
+/** Row-remainder section */
+
 .expression-container .table-component table tbody .table-row .row-remainder-content {
   display: inline-block;
   box-sizing: border-box;
 }
 
-.table-handler .pf-c-popover__arrow {
+/** Hiding popover arrow for the Table Handler */
+
+.boxed-expression-editor .table-handler .pf-c-popover__arrow {
   display: none;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.tsx
@@ -15,65 +15,17 @@
  */
 
 import "./Table.css";
-import {
-  Column,
-  ColumnInstance,
-  ContextMenuEvent,
-  DataRecord,
-  Row,
-  useBlockLayout,
-  useResizeColumns,
-  useTable,
-} from "react-table";
+import { ColumnInstance, ContextMenuEvent, DataRecord, useBlockLayout, useResizeColumns, useTable } from "react-table";
 import { TableComposable } from "@patternfly/react-table";
 import * as React from "react";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { EditableCell } from "./EditableCell";
-import { CellProps, TableHandlerConfiguration, TableHeaderVisibility, TableOperation } from "../../api";
+import { TableOperation, TableProps } from "../../api";
 import * as _ from "lodash";
 import { TableBody } from "./TableBody";
 import { TableHandler } from "./TableHandler";
 import { TableHeader } from "./TableHeader";
 import { BoxedExpressionGlobalContext } from "../../context";
-
-export interface TableProps {
-  /** Table identifier, useful for nested structures */
-  tableId?: string;
-  /** Optional children element to be appended below the table content */
-  children?: React.ReactElement[];
-  /** The prefix to be used for the column name */
-  columnPrefix?: string;
-  /** Optional label to be used for the edit popover that appears when clicking on column header */
-  editColumnLabel?: string;
-  /** For each column there is a default component to be used to render the related cell */
-  defaultCell?: {
-    [columnName: string]: React.FunctionComponent<CellProps>;
-  };
-  /** Table's columns */
-  columns: Column[];
-  /** Table's cells */
-  rows: DataRecord[];
-  /** Function to be executed when columns are modified */
-  onColumnsUpdate?: (columns: Column[]) => void;
-  /** Function to be executed when one or more rows are modified */
-  onRowsUpdate?: (rows: DataRecord[]) => void;
-  /** Function to be executed when a single row gets modified */
-  onSingleRowUpdate?: (rowIndex: number, row: DataRecord) => void;
-  /** Function to be executed when adding a new row to the table */
-  onRowAdding?: () => DataRecord;
-  /** Custom configuration for the table handler */
-  handlerConfiguration: TableHandlerConfiguration;
-  /** The way in which the header will be rendered */
-  headerVisibility?: TableHeaderVisibility;
-  /** Number of levels in the header, 0-based */
-  headerLevels?: number;
-  /** Custom function for getting row key prop, and avoid using the row index */
-  getRowKey?: (row: Row) => string;
-  /** Custom function for getting column key prop, and avoid using the column index */
-  getColumnKey?: (column: Column) => string;
-  /** Custom function called for manually resetting a row */
-  resetRowCustomFunction?: (row: DataRecord) => DataRecord;
-}
 
 export const NO_TABLE_CONTEXT_MENU_CLASS = "no-table-context-menu";
 

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.tsx
@@ -44,7 +44,6 @@ export const Table: React.FunctionComponent<TableProps> = ({
   editColumnLabel,
   onColumnsUpdate,
   onRowsUpdate,
-  onSingleRowUpdate,
   onRowAdding = () => ({}),
   defaultCell,
   rows,
@@ -112,17 +111,13 @@ export const Table: React.FunctionComponent<TableProps> = ({
     });
   }, []);
 
-  const onRowUpdate = useCallback(
-    (rowIndex: number, updatedRow: DataRecord) => {
-      onSingleRowUpdate?.(rowIndex, updatedRow);
-      setTableRows((prevTableCells) => {
-        const updatedRows = [...prevTableCells];
-        updatedRows[rowIndex] = updatedRow;
-        return updatedRows;
-      });
-    },
-    [onSingleRowUpdate]
-  );
+  const onRowUpdate = useCallback((rowIndex: number, updatedRow: DataRecord) => {
+    setTableRows((prevTableCells) => {
+      const updatedRows = [...prevTableCells];
+      updatedRows[rowIndex] = updatedRow;
+      return updatedRows;
+    });
+  }, []);
 
   const defaultColumn = {
     minWidth: 150,

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.tsx
@@ -51,6 +51,7 @@ export const Table: React.FunctionComponent<TableProps> = ({
   handlerConfiguration,
   headerVisibility,
   headerLevels = 0,
+  skipLastHeaderGroup = false,
   getRowKey = (row) => row.id as string,
   getColumnKey = (column) => column.id as string,
   resetRowCustomFunction,
@@ -248,6 +249,7 @@ export const Table: React.FunctionComponent<TableProps> = ({
           tableInstance={tableInstance}
           editColumnLabel={editColumnLabel}
           headerVisibility={headerVisibility}
+          skipLastHeaderGroup={skipLastHeaderGroup}
           tableRows={tableRows}
           onRowsUpdate={onRowsUpdateCallback}
           tableColumns={tableColumns}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableBody.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableBody.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import { useCallback, useMemo } from "react";
+import { Tbody, Td, Tr } from "@patternfly/react-table";
+import { TableHeaderVisibility } from "../../api";
+import { Cell, Column, Row, TableInstance } from "react-table";
+import { DRAWER_SPLITTER_ELEMENT } from "../Resizer";
+
+export interface TableBodyProps {
+  /** Table instance */
+  tableInstance: TableInstance;
+  /** The way in which the header will be rendered */
+  headerVisibility?: TableHeaderVisibility;
+  /** Optional children element to be appended below the table content */
+  children?: React.ReactElement[];
+  /** Custom function for getting row key prop, and avoid using the row index */
+  getRowKey: (row: Row) => string;
+  /** Custom function for getting column key prop, and avoid using the column index */
+  getColumnKey: (column: Column) => string;
+}
+
+export const TableBody: React.FunctionComponent<TableBodyProps> = ({
+  tableInstance,
+  children,
+  headerVisibility = TableHeaderVisibility.Full,
+  getRowKey,
+  getColumnKey,
+}) => {
+  const renderCellResizer = useCallback(
+    (cell: Cell) => (
+      <div
+        className="pf-c-drawer drawer-on-body"
+        {...(cell.column.canResizeOnCell ? cell.column.getResizerProps() : {})}
+      >
+        {DRAWER_SPLITTER_ELEMENT}
+      </div>
+    ),
+    []
+  );
+
+  const renderCell = useCallback(
+    (cellIndex: number, cell: Cell, rowIndex: number) => (
+      <Td
+        {...(cellIndex === 0 ? {} : cell.getCellProps())}
+        {...tableInstance.getTdProps(cellIndex, rowIndex)}
+        key={`${getColumnKey(cell.column)}-${cellIndex}`}
+        data-ouia-component-id={"expression-column-" + cellIndex}
+        className={cellIndex === 0 ? "counter-cell" : "data-cell"}
+      >
+        {cellIndex === 0 ? rowIndex + 1 : cell.render("Cell")}
+        {cell.column.canResizeOnCell ? renderCellResizer(cell) : null}
+      </Td>
+    ),
+    [getColumnKey, renderCellResizer, tableInstance]
+  );
+
+  const renderBodyRow = useCallback(
+    (row: Row, rowIndex: number) => (
+      <Tr
+        className="table-row"
+        {...row.getRowProps()}
+        key={`${getRowKey(row)}-${rowIndex}`}
+        ouiaId={"expression-row-" + rowIndex}
+      >
+        {row.cells.map((cell: Cell, cellIndex: number) => renderCell(cellIndex, cell, rowIndex))}
+      </Tr>
+    ),
+    [getRowKey, renderCell]
+  );
+
+  const renderAdditiveRow = useMemo(
+    () => (
+      <Tr className="table-row additive-row">
+        <Td role="cell" className="empty-cell">
+          <br />
+        </Td>
+        {children?.map((child, childIndex) => {
+          return (
+            <Td
+              role="cell"
+              key={childIndex}
+              className="row-remainder-content"
+              style={{
+                width: tableInstance.allColumns[childIndex + 1].width,
+                minWidth: tableInstance.allColumns[childIndex + 1].minWidth,
+              }}
+            >
+              {child}
+            </Td>
+          );
+        })}
+      </Tr>
+    ),
+    [children, tableInstance.allColumns]
+  );
+
+  return (
+    <Tbody
+      className={`${headerVisibility === TableHeaderVisibility.None ? "missing-header" : ""}`}
+      {...tableInstance.getTableBodyProps()}
+    >
+      {tableInstance.rows.map((row: Row, rowIndex: number) => {
+        tableInstance.prepareRow(row);
+        return renderBodyRow(row, rowIndex);
+      })}
+      {children ? renderAdditiveRow : null}
+    </Tbody>
+  );
+};

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableBody.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableBody.tsx
@@ -54,18 +54,22 @@ export const TableBody: React.FunctionComponent<TableBodyProps> = ({
   );
 
   const renderCell = useCallback(
-    (cellIndex: number, cell: Cell, rowIndex: number) => (
-      <Td
-        {...(cellIndex === 0 ? {} : cell.getCellProps())}
-        {...tableInstance.getTdProps(cellIndex, rowIndex)}
-        key={`${getColumnKey(cell.column)}-${cellIndex}`}
-        data-ouia-component-id={"expression-column-" + cellIndex}
-        className={cellIndex === 0 ? "counter-cell" : "data-cell"}
-      >
-        {cellIndex === 0 ? rowIndex + 1 : cell.render("Cell")}
-        {cell.column.canResizeOnCell ? renderCellResizer(cell) : null}
-      </Td>
-    ),
+    (cellIndex: number, cell: Cell, rowIndex: number) => {
+      const cellType = cellIndex === 0 ? "counter-cell" : "data-cell";
+      const canResize = cell.column.canResizeOnCell ? "has-resizer" : "";
+      return (
+        <Td
+          {...(cellIndex === 0 ? {} : cell.getCellProps())}
+          {...tableInstance.getTdProps(cellIndex, rowIndex)}
+          key={`${getColumnKey(cell.column)}-${cellIndex}`}
+          data-ouia-component-id={"expression-column-" + cellIndex}
+          className={`${cellType} ${canResize}`}
+        >
+          {cellIndex === 0 ? rowIndex + 1 : cell.render("Cell")}
+          {cell.column.canResizeOnCell ? renderCellResizer(cell) : null}
+        </Td>
+      );
+    },
     [getColumnKey, renderCellResizer, tableInstance]
   );
 

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHandler.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHandler.tsx
@@ -120,21 +120,30 @@ export const TableHandler: React.FunctionComponent<TableHandlerProps> = ({
     [generateNextAvailableColumnName]
   );
 
+  /** These column operations have impact also on the collection of cells */
+  const updateColumnsThenRows = useCallback(
+    (columns) => {
+      onColumnsUpdate(columns);
+      onRowsUpdate(tableRows.current);
+    },
+    [onColumnsUpdate, onRowsUpdate, tableRows]
+  );
+
   const handlingOperation = useCallback(
     (tableOperation: TableOperation) => {
       switch (tableOperation) {
         case TableOperation.ColumnInsertLeft:
-          onColumnsUpdate(
+          updateColumnsThenRows(
             insertBefore(tableColumns.current, selectedColumnIndex, generateNextAvailableColumn(tableColumns.current))
           );
           break;
         case TableOperation.ColumnInsertRight:
-          onColumnsUpdate(
+          updateColumnsThenRows(
             insertAfter(tableColumns.current, selectedColumnIndex, generateNextAvailableColumn(tableColumns.current))
           );
           break;
         case TableOperation.ColumnDelete:
-          onColumnsUpdate(deleteAt(tableColumns.current, selectedColumnIndex));
+          updateColumnsThenRows(deleteAt(tableColumns.current, selectedColumnIndex));
           break;
         case TableOperation.RowInsertAbove:
           setTableRows((prevTableRows) => insertBefore(prevTableRows, selectedRowIndex, onRowAdding()));
@@ -154,7 +163,7 @@ export const TableHandler: React.FunctionComponent<TableHandlerProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       generateNextAvailableColumn,
-      onColumnsUpdate,
+      updateColumnsThenRows,
       onRowAdding,
       selectedColumnIndex,
       selectedRowIndex,

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHandler.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHandler.tsx
@@ -28,12 +28,14 @@ export interface TableHandlerProps {
   columnPrefix: string;
   /** Columns instance */
   tableColumns: React.MutableRefObject<Column[]>;
-  /** Function for setting table rows */
-  setTableRows: React.Dispatch<React.SetStateAction<DataRecord[]>>;
   /** Last selected column index */
   lastSelectedColumnIndex: number;
   /** Last selected row index */
   lastSelectedRowIndex: number;
+  /** Rows instance */
+  tableRows: React.MutableRefObject<DataRecord[]>;
+  /** Function to be executed when one or more rows are modified */
+  onRowsUpdate: (rows: DataRecord[]) => void;
   /** Function to be executed when adding a new row to the table */
   onRowAdding: () => DataRecord;
   /** Show/hide table handler */
@@ -55,9 +57,10 @@ export interface TableHandlerProps {
 export const TableHandler: React.FunctionComponent<TableHandlerProps> = ({
   columnPrefix,
   tableColumns,
-  setTableRows,
   lastSelectedColumnIndex,
   lastSelectedRowIndex,
+  tableRows,
+  onRowsUpdate,
   onRowAdding,
   showTableHandler,
   setShowTableHandler,
@@ -146,16 +149,16 @@ export const TableHandler: React.FunctionComponent<TableHandlerProps> = ({
           updateColumnsThenRows(deleteAt(tableColumns.current, selectedColumnIndex));
           break;
         case TableOperation.RowInsertAbove:
-          setTableRows((prevTableRows) => insertBefore(prevTableRows, selectedRowIndex, onRowAdding()));
+          onRowsUpdate(insertBefore(tableRows.current, selectedRowIndex, onRowAdding()));
           break;
         case TableOperation.RowInsertBelow:
-          setTableRows((prevTableRows) => insertAfter(prevTableRows, selectedRowIndex, onRowAdding()));
+          onRowsUpdate(insertAfter(tableRows.current, selectedRowIndex, onRowAdding()));
           break;
         case TableOperation.RowDelete:
-          setTableRows((prevTableRows) => deleteAt(prevTableRows, selectedRowIndex));
+          onRowsUpdate(deleteAt(tableRows.current, selectedRowIndex));
           break;
         case TableOperation.RowClear:
-          setTableRows((prevTableRows) => clearAt(prevTableRows, selectedRowIndex));
+          onRowsUpdate(clearAt(tableRows.current, selectedRowIndex));
           break;
       }
       setShowTableHandler(false);
@@ -165,11 +168,12 @@ export const TableHandler: React.FunctionComponent<TableHandlerProps> = ({
       generateNextAvailableColumn,
       updateColumnsThenRows,
       onRowAdding,
+      onRowsUpdate,
       selectedColumnIndex,
       selectedRowIndex,
       setShowTableHandler,
-      setTableRows,
       tableColumns,
+      tableRows,
     ]
   );
 

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHeader.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHeader.tsx
@@ -98,7 +98,7 @@ export const TableHeader: React.FunctionComponent<TableHeaderProps> = ({
   const renderHeaderCellInfo = useCallback(
     (column) => (
       <div className="header-cell-info" data-ouia-component-type="expression-column-header-cell-info">
-        <p className="pf-u-text-truncate">{column.label}</p>
+        {column.headerCellElement ? column.headerCellElement : <p className="pf-u-text-truncate">{column.label}</p>}
         {column.dataType ? <p className="pf-u-text-truncate data-type">({column.dataType})</p> : null}
       </div>
     ),

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHeader.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHeader.tsx
@@ -21,6 +21,7 @@ import * as _ from "lodash";
 import { Column, ColumnInstance, DataRecord, HeaderGroup, TableInstance } from "react-table";
 import { EditExpressionMenu } from "../EditExpressionMenu";
 import { DataType, TableHeaderVisibility } from "../../api";
+import { DRAWER_SPLITTER_ELEMENT } from "../Resizer";
 
 export interface TableHeaderProps {
   /** Table instance */
@@ -131,9 +132,7 @@ export const TableHeader: React.FunctionComponent<TableHeaderProps> = ({
             className={`pf-c-drawer ${!column.canResize ? "resizer-disabled" : ""}`}
             {...(column.canResize ? column.getResizerProps() : {})}
           >
-            <div className="pf-c-drawer__splitter pf-m-vertical">
-              <div className="pf-c-drawer__splitter-handle" />
-            </div>
+            {DRAWER_SPLITTER_ELEMENT}
           </div>
         </div>
       </Th>

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHeader.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHeader.tsx
@@ -150,7 +150,7 @@ export const TableHeader: React.FunctionComponent<TableHeaderProps> = ({
   const renderHeaderGroups = useMemo(
     () =>
       tableInstance.headerGroups.map((headerGroup: HeaderGroup) => (
-        <Tr key={headerGroup.accessor} {...headerGroup.getHeaderGroupProps()}>
+        <Tr key={headerGroup.getHeaderGroupProps().key} {...headerGroup.getHeaderGroupProps()}>
           {headerGroup.headers.map((column: ColumnInstance, columnIndex: number) => renderColumn(column, columnIndex))}
         </Tr>
       )),

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHeader.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHeader.tsx
@@ -26,40 +26,43 @@ import { DRAWER_SPLITTER_ELEMENT } from "../Resizer";
 export interface TableHeaderProps {
   /** Table instance */
   tableInstance: TableInstance;
-  /** Columns instance */
-  tableColumns: React.MutableRefObject<Column[]>;
-  /** Function for setting table rows */
-  setTableRows: React.Dispatch<React.SetStateAction<DataRecord[]>>;
+  /** Rows instance */
+  tableRows: React.MutableRefObject<DataRecord[]>;
+  /** Function to be executed when one or more rows are modified */
+  onRowsUpdate: (rows: DataRecord[]) => void;
   /** Optional label to be used for the edit popover that appears when clicking on column header */
   editColumnLabel?: string;
   /** The way in which the header will be rendered */
   headerVisibility?: TableHeaderVisibility;
   /** Custom function for getting column key prop, and avoid using the column index */
   getColumnKey: (column: Column) => string;
+  /** Columns instance */
+  tableColumns: React.MutableRefObject<Column[]>;
   /** Function to be executed when columns are modified */
   onColumnsUpdate: (columns: Column[]) => void;
 }
 
 export const TableHeader: React.FunctionComponent<TableHeaderProps> = ({
   tableInstance,
-  tableColumns,
-  setTableRows,
+  tableRows,
+  onRowsUpdate,
   editColumnLabel,
   headerVisibility = TableHeaderVisibility.Full,
   getColumnKey,
+  tableColumns,
   onColumnsUpdate,
 }) => {
   const updateColumnNameInRows = useCallback(
     (prevColumnName: string, newColumnName: string) =>
-      setTableRows((prevTableCells) => {
-        return _.map(prevTableCells, (tableCells) => {
+      onRowsUpdate(
+        _.map(tableRows.current, (tableCells) => {
           const assignedCellValue = tableCells[prevColumnName]!;
           delete tableCells[prevColumnName];
           tableCells[newColumnName] = assignedCellValue;
           return tableCells;
-        });
-      }),
-    [setTableRows]
+        })
+      ),
+    [onRowsUpdate, tableRows]
   );
 
   const onColumnNameOrDataTypeUpdate = useCallback(

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHeader.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHeader.tsx
@@ -34,6 +34,8 @@ export interface TableHeaderProps {
   editColumnLabel?: string;
   /** The way in which the header will be rendered */
   headerVisibility?: TableHeaderVisibility;
+  /** True, for skipping the creation in the DOM of the last defined header group */
+  skipLastHeaderGroup: boolean;
   /** Custom function for getting column key prop, and avoid using the column index */
   getColumnKey: (column: Column) => string;
   /** Columns instance */
@@ -48,6 +50,7 @@ export const TableHeader: React.FunctionComponent<TableHeaderProps> = ({
   onRowsUpdate,
   editColumnLabel,
   headerVisibility = TableHeaderVisibility.Full,
+  skipLastHeaderGroup,
   getColumnKey,
   tableColumns,
   onColumnsUpdate,
@@ -147,14 +150,21 @@ export const TableHeader: React.FunctionComponent<TableHeaderProps> = ({
     [renderCountColumn, renderResizableHeaderCell]
   );
 
+  const getHeaderGroups = useCallback(
+    (tableInstance) => {
+      return skipLastHeaderGroup ? _.dropRight(tableInstance.headerGroups) : tableInstance.headerGroups;
+    },
+    [skipLastHeaderGroup]
+  );
+
   const renderHeaderGroups = useMemo(
     () =>
-      tableInstance.headerGroups.map((headerGroup: HeaderGroup) => (
+      getHeaderGroups(tableInstance).map((headerGroup: HeaderGroup) => (
         <Tr key={headerGroup.getHeaderGroupProps().key} {...headerGroup.getHeaderGroupProps()}>
           {headerGroup.headers.map((column: ColumnInstance, columnIndex: number) => renderColumn(column, columnIndex))}
         </Tr>
       )),
-    [renderColumn, tableInstance.headerGroups]
+    [getHeaderGroups, renderColumn, tableInstance]
   );
 
   const renderAtLevelInHeaderGroups = useCallback(

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHeader.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/TableHeader.tsx
@@ -156,20 +156,26 @@ export const TableHeader: React.FunctionComponent<TableHeaderProps> = ({
     [renderColumn, tableInstance.headerGroups]
   );
 
-  const renderLastLevelInHeaderGroups = useMemo(
-    () => (
+  const renderAtLevelInHeaderGroups = useCallback(
+    (level: number) => (
       <Tr>
-        {_.last(
-          tableInstance.headerGroups as HeaderGroup[]
+        {_.nth(
+          tableInstance.headerGroups as HeaderGroup[],
+          level
         )!.headers.map((column: ColumnInstance, columnIndex: number) => renderColumn(column, columnIndex))}
       </Tr>
     ),
     [renderColumn, tableInstance.headerGroups]
   );
 
-  return headerVisibility === TableHeaderVisibility.None ? null : (
-    <Thead noWrap>
-      {headerVisibility === TableHeaderVisibility.OnlyLastLevel ? renderLastLevelInHeaderGroups : renderHeaderGroups}
-    </Thead>
-  );
+  switch (headerVisibility) {
+    case TableHeaderVisibility.Full:
+      return <Thead noWrap>{renderHeaderGroups}</Thead>;
+    case TableHeaderVisibility.LastLevel:
+      return <Thead noWrap>{renderAtLevelInHeaderGroups(-1)}</Thead>;
+    case TableHeaderVisibility.SecondToLastLevel:
+      return <Thead noWrap>{renderAtLevelInHeaderGroups(-2)}</Thead>;
+    default:
+      return null;
+  }
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/index.ts
@@ -16,6 +16,7 @@
 
 export * from "./EditableCell";
 export * from "./Table";
+export * from "./TableBody";
 export * from "./TableHandler";
 export * from "./TableHandlerMenu";
 export * from "./TableHeader";

--- a/kie-wb-common-react/boxed-expression-editor/src/hooks/Hooks.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/hooks/Hooks.ts
@@ -16,55 +16,6 @@
 
 import { RefObject, useCallback, useEffect, useRef, useState } from "react";
 
-export function useDragEvents(): {
-  setResizerElement: (element: HTMLDivElement) => void;
-  dragItHorizontally: (x: number) => void;
-} {
-  let resizerElement: HTMLDivElement;
-  let mouseDownEvent: MouseEvent;
-
-  const initMouseDownEvent = (element: HTMLDivElement) => {
-    mouseDownEvent = new MouseEvent("mousedown", {
-      clientX: element.getBoundingClientRect().left,
-      clientY: element.getBoundingClientRect().top,
-      bubbles: true,
-      cancelable: true,
-    });
-  };
-
-  const moveHorizontallyBy = (x: number) => {
-    resizerElement.dispatchEvent(
-      new MouseEvent("mousemove", {
-        clientX: resizerElement.getBoundingClientRect().left + x,
-        clientY: resizerElement.getBoundingClientRect().top,
-        bubbles: true,
-        cancelable: true,
-      })
-    );
-  };
-
-  const mouseUpEvent = new MouseEvent("mouseup", {
-    bubbles: true,
-    cancelable: true,
-  });
-
-  const setResizerElement = (element: HTMLDivElement) => {
-    resizerElement = element;
-    initMouseDownEvent(resizerElement);
-  };
-
-  const dragItHorizontally = (x: number) => {
-    resizerElement.dispatchEvent(mouseDownEvent);
-    moveHorizontallyBy(x);
-    resizerElement.dispatchEvent(mouseUpEvent);
-  };
-
-  return {
-    setResizerElement,
-    dragItHorizontally,
-  };
-}
-
 export function useContextMenuHandler(): {
   contextMenuRef: RefObject<HTMLDivElement>;
   contextMenuXPos: string;

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/BoxedExpressionEditorI18n.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/BoxedExpressionEditorI18n.ts
@@ -33,11 +33,13 @@ interface BoxedExpressionEditorDictionary extends ReferenceDictionary<BoxedExpre
   editContextEntry: string;
   editExpression: string;
   editRelation: string;
+  enterFunction: string;
   function: string;
   invocation: string;
   list: string;
   literalExpression: string;
   name: string;
+  parameters: string;
   relation: string;
   rows: string;
   rowOperations: {

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/BoxedExpressionEditorI18n.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/BoxedExpressionEditorI18n.ts
@@ -32,6 +32,7 @@ interface BoxedExpressionEditorDictionary extends ReferenceDictionary<BoxedExpre
   decisionTable: string;
   editContextEntry: string;
   editExpression: string;
+  editParameter: string;
   editRelation: string;
   enterFunction: string;
   function: string;

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
@@ -34,11 +34,13 @@ export const en: BoxedExpressionEditorI18n = {
   editContextEntry: "Edit Context Entry",
   editExpression: "Edit Expression",
   editRelation: "Edit Relation",
+  enterFunction: "Enter function",
   function: "Function",
   invocation: "Invocation",
   list: "List",
   literalExpression: "Literal expression",
   name: "Name",
+  parameters: "PARAMETERS",
   relation: "Relation",
   rowOperations: {
     clear: "Clear",

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
@@ -33,6 +33,7 @@ export const en: BoxedExpressionEditorI18n = {
   decisionTable: "Decision Table",
   editContextEntry: "Edit Context Entry",
   editExpression: "Edit Expression",
+  editParameter: "Edit Parameter",
   editRelation: "Edit Relation",
   enterFunction: "Enter function",
   function: "Function",


### PR DESCRIPTION
What this PR includes:
- Invocation Expression (see [there](https://vpellegrino.github.io/kie-wb-common/) in action)
- LiteralExpression, Table, and components based on table, performance enhancements: `useState` used only to trigger component tree rendering
- Table modularity improvement: `TableBody` component
- Removed unused Hooks