### PR TITLE
KOGITO-3634: Create "FunctionContainer" component + KOGITO-3635 Create "FeelFunction" component

### DIFF
--- a/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
@@ -25,6 +25,7 @@ import {
   DataType,
   ExpressionContainerProps,
   ExpressionProps,
+  FunctionProps,
   InvocationProps,
   ListProps,
   LiteralExpressionProps,
@@ -50,6 +51,7 @@ export const App: React.FunctionComponent = () => {
     broadcastContextExpressionDefinition: (definition: ContextProps) => setUpdatedExpression(definition),
     broadcastListExpressionDefinition: (definition: ListProps) => setUpdatedExpression(definition),
     broadcastInvocationExpressionDefinition: (definition: InvocationProps) => setUpdatedExpression(definition),
+    broadcastFunctionExpressionDefinition: (definition: FunctionProps) => setUpdatedExpression(definition),
   };
 
   return (
@@ -59,7 +61,8 @@ export const App: React.FunctionComponent = () => {
       </div>
       <div className="updated-json">
         <p className="disclaimer">
-          ⚠ Currently, JSON gets updated only for literal expression, relation, context, list and invocation logic types
+          ⚠ Currently, JSON gets updated only for literal expression, relation, context, list, invocation and function
+          logic types
         </p>
         <pre>{JSON.stringify(updatedExpression, null, 2)}</pre>
       </div>

--- a/kie-wb-common-react/boxed-expression-editor/src/@types/react-table.d.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/@types/react-table.d.ts
@@ -55,7 +55,7 @@ declare module "react-table" {
     /** Column identifier */
     accessor: string;
     /** Column label */
-    label: string;
+    label: string | JSX.Element;
     /** Custom Element to be rendered in place of the column label */
     headerCellElement?: JSX.Element;
     /** Column data type */

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from "@testing-library/react";
+import {
+  activateSelector,
+  EDIT_EXPRESSION_DATA_TYPE,
+  flushPromises,
+  usingTestingBoxedExpressionI18nContext,
+} from "../test-utils";
+import { DEFAULT_FIRST_PARAM_NAME, FunctionExpression } from "../../../components/FunctionExpression";
+import * as React from "react";
+import { DataType, EntryInfo, FunctionKind, FunctionProps, LogicType } from "../../../api";
+import { act } from "react-dom/test-utils";
+import * as _ from "lodash";
+
+jest.useFakeTimers();
+
+describe("FunctionExpression tests", () => {
+  test("should show a table with two levels visible header, with one row and one column", () => {
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <FunctionExpression logicType={LogicType.Function} functionKind={FunctionKind.Feel} formalParameters={[]} />
+      ).wrapper
+    );
+
+    expect(container.querySelector(".function-expression")).toBeTruthy();
+    expect(container.querySelector(".function-expression table")).toBeTruthy();
+    expect(container.querySelector(".function-expression table thead")).toBeTruthy();
+    expect(container.querySelectorAll(".function-expression table thead tr")).toHaveLength(2);
+    expect(container.querySelectorAll(".function-expression table tbody tr")).toHaveLength(1);
+    expect(container.querySelectorAll(".function-expression table tbody td.data-cell")).toHaveLength(1);
+  });
+
+  test("should show a section in the header, with the list of parameters", () => {
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <FunctionExpression
+          logicType={LogicType.Function}
+          functionKind={FunctionKind.Feel}
+          formalParameters={[{ name: DEFAULT_FIRST_PARAM_NAME, dataType: DataType.Undefined }]}
+        />
+      ).wrapper
+    );
+
+    expect(container.querySelector(".function-expression table thead .parameters-list")).toBeTruthy();
+    expect(container.querySelector(".function-expression table thead .parameters-list p")).toContainHTML(
+      `${DEFAULT_FIRST_PARAM_NAME}`
+    );
+  });
+
+  describe("Formal Parameters", () => {
+    beforeEach(() => {
+      jest.clearAllTimers();
+    });
+
+    test("should render no parameter, if passed property is empty array", async () => {
+      const { container, baseElement } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <FunctionExpression logicType={LogicType.Function} functionKind={FunctionKind.Feel} formalParameters={[]} />
+        ).wrapper
+      );
+      await activateSelector(container as HTMLElement, ".parameters-list");
+
+      expect(baseElement.querySelector(".parameters-editor")).toBeTruthy();
+      expect(baseElement.querySelector(".parameters-editor .parameters-container")).toBeTruthy();
+      expect(baseElement.querySelectorAll(".parameters-editor .parameters-container .parameter-entry")).toHaveLength(0);
+    });
+
+    test("should render all parameters, belonging to the passed property", async () => {
+      const paramName = "param";
+      const paramDataType = DataType.Any;
+
+      const { container, baseElement } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <FunctionExpression
+            logicType={LogicType.Function}
+            functionKind={FunctionKind.Feel}
+            formalParameters={[{ name: paramName, dataType: paramDataType }]}
+          />
+        ).wrapper
+      );
+      await activateSelector(container as HTMLElement, ".parameters-list");
+
+      expect(baseElement.querySelectorAll(".parameters-editor .parameters-container .parameter-entry")).toHaveLength(1);
+      expect((baseElement.querySelector(".parameter-name") as HTMLInputElement).value).toBe(paramName);
+      expect((baseElement.querySelector(EDIT_EXPRESSION_DATA_TYPE)! as HTMLInputElement).value).toBe(paramDataType);
+    });
+
+    test("should update the parameter name, when it gets changed by the user", async () => {
+      const newParamName = "new param";
+      const mockedBroadcastDefinition = jest.fn();
+      mockBroadcastDefinition(mockedBroadcastDefinition);
+
+      const { container, baseElement } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <FunctionExpression
+            logicType={LogicType.Function}
+            functionKind={FunctionKind.Feel}
+            formalParameters={[{ name: "param", dataType: DataType.Any }]}
+          />
+        ).wrapper
+      );
+      await activateSelector(container as HTMLElement, ".parameters-list");
+      await act(async () => {
+        (baseElement.querySelector(".parameter-name") as HTMLInputElement)!.value = newParamName;
+        (baseElement.querySelector(".parameter-name") as HTMLInputElement)!.dispatchEvent(new Event("change"));
+        (baseElement.querySelector(".parameter-name") as HTMLInputElement)!.dispatchEvent(new Event("blur"));
+      });
+
+      checkFormalParameters(mockedBroadcastDefinition, [
+        {
+          dataType: DataType.Any,
+          name: `${newParamName}`,
+        },
+      ]);
+    });
+
+    test("should update the parameter data type, when it gets changed by the user", async () => {
+      const mockedBroadcastDefinition = jest.fn();
+      mockBroadcastDefinition(mockedBroadcastDefinition);
+
+      const { container, baseElement } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <FunctionExpression
+            logicType={LogicType.Function}
+            functionKind={FunctionKind.Feel}
+            formalParameters={[{ name: "param", dataType: DataType.Undefined }]}
+          />
+        ).wrapper
+      );
+      await activateSelector(container as HTMLElement, ".parameters-list");
+      await act(async () => {
+        (baseElement.querySelector(
+          "[data-ouia-component-id='edit-expression-data-type'] button"
+        ) as HTMLButtonElement).click();
+        await flushPromises();
+        jest.runAllTimers();
+        (baseElement.querySelector(`[data-ouia-component-id='${DataType.Boolean}']`) as HTMLButtonElement).click();
+      });
+
+      checkFormalParameters(mockedBroadcastDefinition, [
+        {
+          dataType: DataType.Boolean,
+          name: "param",
+        },
+      ]);
+    });
+
+    test("should add a new parameter, when the user adds it", async () => {
+      const mockedBroadcastDefinition = jest.fn();
+      mockBroadcastDefinition(mockedBroadcastDefinition);
+
+      const { container, baseElement } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <FunctionExpression logicType={LogicType.Function} functionKind={FunctionKind.Feel} formalParameters={[]} />
+        ).wrapper
+      );
+      await activateSelector(container as HTMLElement, ".parameters-list");
+      await act(async () => {
+        (baseElement.querySelector("button.add-parameter") as HTMLButtonElement).click();
+      });
+
+      checkFormalParameters(mockedBroadcastDefinition, [
+        {
+          dataType: DataType.Undefined,
+          name: DEFAULT_FIRST_PARAM_NAME,
+        },
+      ]);
+    });
+
+    test("should have no parameter, when the user delete the only existing one", async () => {
+      const mockedBroadcastDefinition = jest.fn();
+      mockBroadcastDefinition(mockedBroadcastDefinition);
+
+      const { container, baseElement } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <FunctionExpression
+            logicType={LogicType.Function}
+            functionKind={FunctionKind.Feel}
+            formalParameters={[
+              {
+                dataType: DataType.Undefined,
+                name: DEFAULT_FIRST_PARAM_NAME,
+              },
+            ]}
+          />
+        ).wrapper
+      );
+      await activateSelector(container as HTMLElement, ".parameters-list");
+      await act(async () => {
+        (baseElement.querySelector("button.delete-parameter") as HTMLButtonElement).click();
+      });
+
+      checkFormalParameters(mockedBroadcastDefinition, []);
+    });
+
+    function checkFormalParameters(mockedBroadcastDefinition: jest.Mock, formalParameters: EntryInfo[]) {
+      expect(mockedBroadcastDefinition).toHaveBeenCalledWith({
+        dataType: undefined,
+        expression: {
+          logicType: "Literal expression",
+        },
+        formalParameters,
+        functionKind: "FEEL",
+        logicType: "Function",
+        name: "p-1",
+        uid: undefined,
+      });
+    }
+
+    function mockBroadcastDefinition(mockedBroadcastDefinition: jest.Mock) {
+      window.beeApi = _.extend(window.beeApi || {}, {
+        broadcastFunctionExpressionDefinition: (definition: FunctionProps) => mockedBroadcastDefinition(definition),
+      });
+    }
+  });
+
+  describe("FEEL Function Kind", () => {
+    test("should show, by default, an entry with an empty literal expression", () => {
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <FunctionExpression logicType={LogicType.Function} functionKind={FunctionKind.Feel} formalParameters={[]} />
+        ).wrapper
+      );
+
+      expect(container.querySelector(".function-expression table tbody td.data-cell")).toBeVisible();
+      expect(container.querySelector(".function-expression table tbody td.data-cell .literal-expression")).toBeTruthy();
+      expect(
+        (container.querySelector(
+          ".function-expression table tbody td.data-cell .literal-expression textarea"
+        ) as HTMLTextAreaElement).value
+      ).toBe("");
+    });
+
+    test("should show an entry corresponding to the passed expression", () => {
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <FunctionExpression
+            logicType={LogicType.Function}
+            functionKind={FunctionKind.Feel}
+            formalParameters={[]}
+            expression={{
+              uid: "id2",
+              logicType: LogicType.Relation,
+            }}
+          />
+        ).wrapper
+      );
+
+      expect(container.querySelector(".function-expression table tbody td.data-cell")).toBeVisible();
+      expect(
+        container.querySelector(".function-expression table tbody td.data-cell .relation-expression")
+      ).toBeTruthy();
+      expect(
+        container.querySelector(".function-expression table tbody td.data-cell .relation-expression table")
+      ).toBeTruthy();
+    });
+  });
+});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionKindSelector.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionKindSelector.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from "@testing-library/react";
+import { activateSelector, usingTestingBoxedExpressionI18nContext } from "../test-utils";
+import * as React from "react";
+import { FunctionKindSelector } from "../../../components/FunctionExpression";
+import { FunctionKind } from "../../../api";
+import * as _ from "lodash";
+
+jest.useFakeTimers();
+
+describe("FunctionKindSelector tests", () => {
+  test("should render passed Function Kind property", async () => {
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <FunctionKindSelector selectedFunctionKind={FunctionKind.Feel} onFunctionKindSelect={_.identity} />
+      ).wrapper
+    );
+
+    await activateSelector(container as HTMLElement, ".selected-function-kind");
+
+    expect(container.querySelector(".selected-function-kind")).toBeTruthy();
+    expect(container.querySelector(".selected-function-kind")).toContainHTML("F");
+  });
+
+  test("should trigger the Function Kind which the user has selected", async () => {
+    const onFunctionKindSelect = (functionKind: FunctionKind) => _.identity(functionKind);
+    const mockedFunctionKindSelect = jest.fn(onFunctionKindSelect);
+
+    const { container, baseElement } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <FunctionKindSelector
+          selectedFunctionKind={FunctionKind.Feel}
+          onFunctionKindSelect={mockedFunctionKindSelect}
+        />
+      ).wrapper
+    );
+
+    await activateSelector(container as HTMLElement, ".selected-function-kind");
+    await activateSelector(baseElement as HTMLElement, "[data-ouia-component-id='JAVA'] > button");
+
+    expect(mockedFunctionKindSelect).toHaveBeenCalled();
+    expect(mockedFunctionKindSelect).toHaveBeenCalledWith(FunctionKind.Java);
+  });
+});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/test-utils.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/test-utils.tsx
@@ -55,6 +55,15 @@ export function usingTestingBoxedExpressionI18nContext(
   };
 }
 
+export async function activateSelector(container: HTMLElement, query: string): Promise<void> {
+  await act(async () => {
+    const selector = container.querySelector(query)! as HTMLElement;
+    selector.click();
+    await flushPromises();
+    jest.runAllTimers();
+  });
+}
+
 export async function activateNameAndDataTypePopover(element: HTMLElement): Promise<void> {
   await act(async () => {
     element.click();

--- a/kie-wb-common-react/boxed-expression-editor/src/api/BoxedExpressionEditor.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/BoxedExpressionEditor.ts
@@ -17,6 +17,7 @@
 import {
   ContextProps,
   ExpressionProps,
+  FunctionProps,
   InvocationProps,
   ListProps,
   LiteralExpressionProps,
@@ -36,6 +37,7 @@ declare global {
       broadcastContextExpressionDefinition: (definition: ContextProps) => void;
       broadcastListExpressionDefinition: (definition: ListProps) => void;
       broadcastInvocationExpressionDefinition: (definition: InvocationProps) => void;
+      broadcastFunctionExpressionDefinition: (definition: FunctionProps) => void;
     };
   }
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ContextEntry.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ContextEntry.ts
@@ -73,6 +73,6 @@ export const generateNextAvailableEntryName = (
 export const getEntryKey = (row: Row): string => (row.original as ContextEntryRecord).entryInfo.name;
 
 export const resetEntry = (row: DataRecord): DataRecord => ({
-  entryInfo: row.entryInfo,
+  ...row,
   entryExpression: { uid: (row.entryExpression as ExpressionProps).uid },
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ContextEntry.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ContextEntry.ts
@@ -63,7 +63,7 @@ export const generateNextAvailableEntryName = (
   namePrefix: string,
   lastIndex: number = entryInfos.length
 ): string => {
-  const candidateName = `${namePrefix}-${lastIndex}`;
+  const candidateName = `${namePrefix}-${lastIndex === 0 ? 1 : lastIndex}`;
   const entryWithCandidateName = _.find(entryInfos, { name: candidateName });
   return entryWithCandidateName ? generateNextAvailableEntryName(entryInfos, namePrefix, lastIndex + 1) : candidateName;
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ContextEntry.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ContextEntry.ts
@@ -21,13 +21,15 @@ import { DataRecord, Row } from "react-table";
 import { TableHandlerConfiguration, TableOperation } from "./Table";
 import { BoxedExpressionEditorI18n } from "../i18n";
 
+export interface EntryInfo {
+  /** Entry name */
+  name: string;
+  /** Entry data type */
+  dataType: DataType;
+}
+
 export interface ContextEntryRecord {
-  entryInfo: {
-    /** Entry name */
-    name: string;
-    /** Entry data type */
-    dataType: DataType;
-  };
+  entryInfo: EntryInfo;
   /** Entry expression */
   entryExpression: ExpressionProps;
   /** Label used for the popover triggered when editing info section */

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ContextEntry.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ContextEntry.ts
@@ -59,15 +59,13 @@ export const getHandlerConfiguration = (
 ];
 
 export const generateNextAvailableEntryName = (
-  contextEntries: ContextEntries,
+  entryInfos: EntryInfo[],
   namePrefix: string,
-  lastIndex: number = contextEntries.length
+  lastIndex: number = entryInfos.length
 ): string => {
   const candidateName = `${namePrefix}-${lastIndex}`;
-  const entryWithCandidateName = _.find(contextEntries, { entryInfo: { name: candidateName } });
-  return entryWithCandidateName
-    ? generateNextAvailableEntryName(contextEntries, namePrefix, lastIndex + 1)
-    : candidateName;
+  const entryWithCandidateName = _.find(entryInfos, { name: candidateName });
+  return entryWithCandidateName ? generateNextAvailableEntryName(entryInfos, namePrefix, lastIndex + 1) : candidateName;
 };
 
 export const getEntryKey = (row: Row): string => (row.original as ContextEntryRecord).entryInfo.name;

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -17,10 +17,11 @@
 import { LogicType } from "./LogicType";
 import { DataType } from "./DataType";
 import { Columns, Rows } from "./Table";
-import { ContextEntries } from "./ContextEntry";
+import { ContextEntries, EntryInfo } from "./ContextEntry";
 import { HitPolicy } from "./HitPolicy";
 import { BuiltinAggregation } from "./BuiltinAggregation";
 import { Clause, DecisionTableRule } from "./DecisionTableRule";
+import { FunctionKind } from "./FunctionKind";
 
 export interface ExpressionProps {
   /** Unique identifier used to identify the expression */
@@ -108,3 +109,33 @@ export interface InvocationProps extends ExpressionProps {
   /** Entry expression width */
   entryExpressionWidth?: number;
 }
+
+export type FunctionProps = {
+  /** Logic type must be Function */
+  logicType: LogicType.Function;
+  /** List of parameters passed to the function */
+  formalParameters?: EntryInfo[];
+} & (
+  | {
+      /** Feel Function */
+      functionKind: FunctionKind.Feel;
+      /** The Expression related to the function */
+      expression?: ExpressionProps;
+    }
+  | {
+      /** Java Function */
+      functionKind: FunctionKind.Java;
+      /** Java class */
+      class?: string;
+      /** Method signature */
+      method?: string;
+    }
+  | {
+      /** Pmml Function */
+      functionKind: FunctionKind.Pmml;
+      /** PMML document */
+      document?: string;
+      /** PMML model */
+      model?: string;
+    }
+);

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -110,32 +110,32 @@ export interface InvocationProps extends ExpressionProps {
   entryExpressionWidth?: number;
 }
 
-export type FunctionProps = {
+export type FunctionProps = ExpressionProps & {
   /** Logic type must be Function */
   logicType: LogicType.Function;
   /** List of parameters passed to the function */
   formalParameters?: EntryInfo[];
 } & (
-  | {
-      /** Feel Function */
-      functionKind: FunctionKind.Feel;
-      /** The Expression related to the function */
-      expression?: ExpressionProps;
-    }
-  | {
-      /** Java Function */
-      functionKind: FunctionKind.Java;
-      /** Java class */
-      class?: string;
-      /** Method signature */
-      method?: string;
-    }
-  | {
-      /** Pmml Function */
-      functionKind: FunctionKind.Pmml;
-      /** PMML document */
-      document?: string;
-      /** PMML model */
-      model?: string;
-    }
-);
+    | {
+        /** Feel Function */
+        functionKind: FunctionKind.Feel;
+        /** The Expression related to the function */
+        expression?: ExpressionProps;
+      }
+    | {
+        /** Java Function */
+        functionKind: FunctionKind.Java;
+        /** Java class */
+        class?: string;
+        /** Method signature */
+        method?: string;
+      }
+    | {
+        /** Pmml Function */
+        functionKind: FunctionKind.Pmml;
+        /** PMML document */
+        document?: string;
+        /** PMML model */
+        model?: string;
+      }
+  );

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -21,7 +21,7 @@ import { ContextEntries, EntryInfo } from "./ContextEntry";
 import { HitPolicy } from "./HitPolicy";
 import { BuiltinAggregation } from "./BuiltinAggregation";
 import { Clause, DecisionTableRule } from "./DecisionTableRule";
-import { FunctionKind } from "./FunctionKind";
+import { FeelFunctionProps, JavaFunctionProps, PmmlFunctionProps } from "./FunctionKind";
 
 export interface ExpressionProps {
   /** Unique identifier used to identify the expression */
@@ -117,27 +117,4 @@ export type FunctionProps = ExpressionProps & {
   formalParameters?: EntryInfo[];
   /** Parameters column width */
   parametersWidth?: number;
-} & (
-    | {
-        /** Feel Function */
-        functionKind: FunctionKind.Feel;
-        /** The Expression related to the function */
-        expression?: ExpressionProps;
-      }
-    | {
-        /** Java Function */
-        functionKind: FunctionKind.Java;
-        /** Java class */
-        class?: string;
-        /** Method signature */
-        method?: string;
-      }
-    | {
-        /** Pmml Function */
-        functionKind: FunctionKind.Pmml;
-        /** PMML document */
-        document?: string;
-        /** PMML model */
-        model?: string;
-      }
-  );
+} & (FeelFunctionProps | JavaFunctionProps | PmmlFunctionProps);

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -115,6 +115,8 @@ export type FunctionProps = ExpressionProps & {
   logicType: LogicType.Function;
   /** List of parameters passed to the function */
   formalParameters?: EntryInfo[];
+  /** Parameters column width */
+  parametersWidth?: number;
 } & (
     | {
         /** Feel Function */

--- a/kie-wb-common-react/boxed-expression-editor/src/api/FunctionKind.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/FunctionKind.ts
@@ -14,8 +14,35 @@
  * limitations under the License.
  */
 
+import { ExpressionProps } from "./ExpressionProps";
+
 export enum FunctionKind {
   Feel = "FEEL",
   Java = "JAVA",
   Pmml = "PMML",
+}
+
+export interface FeelFunctionProps {
+  /** Feel Function */
+  functionKind: FunctionKind.Feel;
+  /** The Expression related to the function */
+  expression?: ExpressionProps;
+}
+
+export interface JavaFunctionProps {
+  /** Java Function */
+  functionKind: FunctionKind.Java;
+  /** Java class */
+  class?: string;
+  /** Method signature */
+  method?: string;
+}
+
+export interface PmmlFunctionProps {
+  /** Pmml Function */
+  functionKind: FunctionKind.Pmml;
+  /** PMML document */
+  document?: string;
+  /** PMML model */
+  model?: string;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/api/FunctionKind.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/FunctionKind.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-export * from "./BoxedExpressionEditor";
-export * from "./BuiltinAggregation";
-export * from "./ContextEntry";
-export * from "./DataType";
-export * from "./DecisionTableRule";
-export * from "./ExpressionProps";
-export * from "./FunctionKind";
-export * from "./HitPolicy";
-export * from "./LogicType";
-export * from "./Table";
+export enum FunctionKind {
+  Feel = "FEEL",
+  Java = "JAVA",
+  Pmml = "PMML",
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/api/Table.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/Table.ts
@@ -27,6 +27,8 @@ export interface TableProps {
   columnPrefix?: string;
   /** Optional label to be used for the edit popover that appears when clicking on column header */
   editColumnLabel?: string;
+  /** Top-left cell custom content */
+  controllerCell?: string | JSX.Element;
   /** For each column there is a default component to be used to render the related cell */
   defaultCell?: {
     [columnName: string]: React.FunctionComponent<CellProps>;
@@ -42,7 +44,7 @@ export interface TableProps {
   /** Function to be executed when adding a new row to the table */
   onRowAdding?: () => DataRecord;
   /** Custom configuration for the table handler */
-  handlerConfiguration: TableHandlerConfiguration;
+  handlerConfiguration?: TableHandlerConfiguration;
   /** The way in which the header will be rendered */
   headerVisibility?: TableHeaderVisibility;
   /** Number of levels in the header, 0-based */

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
@@ -19,10 +19,12 @@ import * as React from "react";
 import { useCallback, useEffect, useState } from "react";
 import {
   ContextEntries,
+  ContextEntryRecord,
   ContextProps,
   DataType,
   DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH,
   DEFAULT_ENTRY_INFO_MIN_WIDTH,
+  EntryInfo,
   ExpressionProps,
   generateNextAvailableEntryName,
   getEntryKey,
@@ -118,7 +120,10 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
   const onRowAdding = useCallback(
     () => ({
       entryInfo: {
-        name: generateNextAvailableEntryName(rows as ContextEntries, "ContextEntry"),
+        name: generateNextAvailableEntryName(
+          _.map(rows, (row: ContextEntryRecord) => row.entryInfo) as EntryInfo[],
+          "ContextEntry"
+        ),
         dataType: DataType.Undefined,
       },
       entryExpression: {},

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
@@ -100,13 +100,13 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
 
   const onColumnsUpdate = useCallback(
     ([expressionColumn]: [ColumnInstance]) => {
-      onUpdatingNameAndDataType?.(expressionColumn.label, expressionColumn.dataType);
+      onUpdatingNameAndDataType?.(expressionColumn.label as string, expressionColumn.dataType);
       setExpressionWidth(_.find(expressionColumn.columns, { accessor: "entryExpression" })?.width as number);
       setInfoWidth(_.find(expressionColumn.columns, { accessor: "entryInfo" })?.width as number);
       setColumns(([prevExpressionColumn]) => [
         {
           ...prevExpressionColumn,
-          label: expressionColumn.label,
+          label: expressionColumn.label as string,
           accessor: expressionColumn.accessor,
           dataType: expressionColumn.dataType,
         },

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/DataTypeSelector.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/DataTypeSelector.tsx
@@ -49,7 +49,7 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
 
   const getDataTypes = useCallback(() => {
     return _.map(Object.values(DataType), (key) => (
-      <SelectOption key={key} value={key}>
+      <SelectOption key={key} value={key} data-ouia-component-id={key}>
         {key}
       </SelectOption>
     ));

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/DataTypeSelector.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/DataTypeSelector.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";
+import * as React from "react";
+import { useCallback, useState } from "react";
+import { useBoxedExpressionEditorI18n } from "../../i18n";
+import * as _ from "lodash";
+import { DataType } from "../../api";
+
+export interface DataTypeSelectorProps {
+  /** The pre-selected data type */
+  selectedDataType: DataType;
+  /** On DataType selection callback */
+  onDataTypeChange: (dataType: DataType) => void;
+}
+
+export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = ({
+  selectedDataType,
+  onDataTypeChange,
+}) => {
+  const { i18n } = useBoxedExpressionEditorI18n();
+
+  const [dataTypeSelectOpen, setDataTypeSelectOpen] = useState(false);
+
+  const onDataTypeSelect = useCallback(
+    (event, selection) => {
+      setDataTypeSelectOpen(false);
+      onDataTypeChange(selection);
+    },
+    [onDataTypeChange]
+  );
+
+  const getDataTypes = useCallback(() => {
+    return _.map(Object.values(DataType), (key) => (
+      <SelectOption key={key} value={key}>
+        {key}
+      </SelectOption>
+    ));
+  }, []);
+
+  const onDataTypeFilter = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      let input: RegExp;
+      try {
+        input = new RegExp(e.target.value, "i");
+      } catch (exception) {
+        return getDataTypes();
+      }
+      return e.target.value !== "" ? getDataTypes().filter((child) => input.test(child.props.value)) : getDataTypes();
+    },
+    [getDataTypes]
+  );
+
+  const onDataTypeSelectToggle = useCallback((isOpen) => setDataTypeSelectOpen(isOpen), []);
+
+  return (
+    <Select
+      ouiaId="edit-expression-data-type"
+      variant={SelectVariant.typeahead}
+      typeAheadAriaLabel={i18n.choose}
+      onToggle={onDataTypeSelectToggle}
+      onSelect={onDataTypeSelect}
+      onFilter={onDataTypeFilter}
+      isOpen={dataTypeSelectOpen}
+      selections={selectedDataType}
+      hasInlineFilter
+      inlineFilterPlaceholderText={i18n.choose}
+    >
+      {getDataTypes()}
+    </Select>
+  );
+};

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/DataTypeSelector.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/DataTypeSelector.tsx
@@ -26,11 +26,14 @@ export interface DataTypeSelectorProps {
   selectedDataType: DataType;
   /** On DataType selection callback */
   onDataTypeChange: (dataType: DataType) => void;
+  /** By default the menu will be appended inline, but it is possible to append on the parent or on other elements */
+  menuAppendTo?: HTMLElement | "inline" | (() => HTMLElement) | "parent";
 }
 
 export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = ({
   selectedDataType,
   onDataTypeChange,
+  menuAppendTo,
 }) => {
   const { i18n } = useBoxedExpressionEditorI18n();
 
@@ -69,6 +72,7 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
 
   return (
     <Select
+      menuAppendTo={menuAppendTo}
       ouiaId="edit-expression-data-type"
       variant={SelectVariant.typeahead}
       typeAheadAriaLabel={i18n.choose}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/EditExpressionMenu.tsx
@@ -20,9 +20,8 @@ import { useCallback, useContext, useEffect, useState } from "react";
 import { PopoverMenu } from "../PopoverMenu";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { DataType, ExpressionProps } from "../../api";
-import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";
-import * as _ from "lodash";
 import { BoxedExpressionGlobalContext } from "../../context";
+import { DataTypeSelector } from "./DataTypeSelector";
 
 export interface EditExpressionMenuProps {
   /** Optional children element to be considered for triggering the edit expression menu */
@@ -65,7 +64,6 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
   dataTypeField = dataTypeField ?? i18n.dataType;
   appendTo = appendTo ?? globalContext.boxedExpressionEditorRef?.current ?? undefined;
 
-  const [dataTypeSelectOpen, setDataTypeSelectOpen] = useState(false);
   const [dataType, setDataType] = useState(selectedDataType);
   const [expressionName, setExpressionName] = useState(selectedExpressionName);
 
@@ -90,40 +88,16 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
     [dataType, onExpressionUpdate]
   );
 
-  const onDataTypeSelect = useCallback(
-    (event, selection) => {
-      setDataTypeSelectOpen(false);
-      setDataType(selection);
+  const onDataTypeChange = useCallback(
+    (dataType: DataType) => {
+      setDataType(dataType);
       onExpressionUpdate({
         name: expressionName,
-        dataType: selection,
+        dataType: dataType,
       });
     },
     [expressionName, onExpressionUpdate]
   );
-
-  const getDataTypes = useCallback(() => {
-    return _.map(Object.values(DataType), (key) => (
-      <SelectOption key={key} value={key}>
-        {key}
-      </SelectOption>
-    ));
-  }, []);
-
-  const onDataTypeFilter = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      let input: RegExp;
-      try {
-        input = new RegExp(e.target.value, "i");
-      } catch (exception) {
-        return getDataTypes();
-      }
-      return e.target.value !== "" ? getDataTypes().filter((child) => input.test(child.props.value)) : getDataTypes();
-    },
-    [getDataTypes]
-  );
-
-  const onDataTypeSelectToggle = useCallback((isOpen) => setDataTypeSelectOpen(isOpen), []);
 
   return (
     <PopoverMenu
@@ -147,20 +121,7 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
           </div>
           <div className="expression-data-type">
             <label>{dataTypeField}</label>
-            <Select
-              ouiaId="edit-expression-data-type"
-              variant={SelectVariant.typeahead}
-              typeAheadAriaLabel={i18n.choose}
-              onToggle={onDataTypeSelectToggle}
-              onSelect={onDataTypeSelect}
-              onFilter={onDataTypeFilter}
-              isOpen={dataTypeSelectOpen}
-              selections={dataType}
-              hasInlineFilter
-              inlineFilterPlaceholderText={i18n.choose}
-            >
-              {getDataTypes()}
-            </Select>
+            <DataTypeSelector selectedDataType={dataType} onDataTypeChange={onDataTypeChange} />
           </div>
         </div>
       }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/EditExpressionMenu/index.ts
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 
+export * from "./DataTypeSelector";
 export * from "./EditExpressionMenu";

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/EditParameters.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/EditParameters.css
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+.boxed-expression-editor .parameters-editor-popover .parameters-editor {
+  padding: 8px 14px;
+}
+
+.boxed-expression-editor .parameters-editor-popover .parameters-editor * {
+  font-size: var(--small-font-size);
+}
+
+.boxed-expression-editor .parameters-editor-popover .parameters-editor .parameters-container {
+  height: 200px;
+  overflow-y: scroll;
+  margin-top: 10px;
+  border: 1px solid #cccccc;
+  padding: 0 5px 5px 5px;
+}
+
+.boxed-expression-editor .parameters-editor-popover .parameters-editor .parameters-container .parameter-entry {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding-top: 5px;
+}
+
+.boxed-expression-editor .parameters-editor-popover .parameters-editor .parameters-container .parameter-entry > :nth-child(1) {
+  width: 30%;
+}
+
+.boxed-expression-editor .parameters-editor-popover .parameters-editor .parameters-container .parameter-entry > :nth-child(2) {
+  width: 40%;
+}
+
+.boxed-expression-editor .parameters-editor-popover .parameters-editor .parameters-container .parameter-entry > :nth-child(3) {
+  width: 25%;
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/EditParameters.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/EditParameters.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import "./EditParameters.css";
+import * as _ from "lodash";
+import { DataTypeSelector } from "../EditExpressionMenu";
+import { Button } from "@patternfly/react-core";
+import { OutlinedTrashAltIcon } from "@patternfly/react-icons";
+import * as React from "react";
+import { ChangeEvent, useCallback } from "react";
+import { DataType, EntryInfo, generateNextAvailableEntryName } from "../../api";
+import { useBoxedExpressionEditorI18n } from "../../i18n";
+
+export interface EditParametersProps {
+  /** List of parameters */
+  parameters: EntryInfo[];
+  /** Function for mutating parameters state */
+  setParameters: React.Dispatch<React.SetStateAction<EntryInfo[]>>;
+}
+
+export const EditParameters: React.FunctionComponent<EditParametersProps> = ({ parameters, setParameters }) => {
+  const { i18n } = useBoxedExpressionEditorI18n();
+
+  const addParameter = useCallback(() => {
+    setParameters((parameters) => [
+      ...parameters,
+      {
+        name: generateNextAvailableEntryName(parameters, "p"),
+        dataType: DataType.Undefined,
+      },
+    ]);
+  }, [setParameters]);
+
+  const onNameChange = useCallback(
+    (index: number) => (event: ChangeEvent<HTMLInputElement>) =>
+      setParameters((parameters) => {
+        parameters[index].name = event.target.value;
+        return [...parameters];
+      }),
+    [setParameters]
+  );
+
+  const onDataTypeChange = useCallback(
+    (index: number) => (dataType: DataType) => {
+      setParameters((parameters) => {
+        parameters[index].dataType = dataType;
+        return [...parameters];
+      });
+    },
+    [setParameters]
+  );
+
+  const onParameterRemove = useCallback(
+    (index: number) => () =>
+      setParameters((parameters) => [...parameters.slice(0, index), ...parameters.slice(index + 1)]),
+    [setParameters]
+  );
+
+  return (
+    <div className="parameters-editor">
+      <Button variant="tertiary" onClick={addParameter} className="add-parameter">
+        {i18n.addParameter}
+      </Button>
+      <div className="parameters-container">
+        {_.map(parameters, (parameter, index) => {
+          return (
+            <div key={`${parameter.name}_${index}`} className="parameter-entry">
+              <input
+                className="parameter-name"
+                type="text"
+                onBlur={onNameChange(index)}
+                defaultValue={parameter.name}
+              />
+              <DataTypeSelector
+                selectedDataType={parameter.dataType}
+                onDataTypeChange={onDataTypeChange(index)}
+                menuAppendTo="parent"
+              />
+              <Button
+                variant="danger"
+                className="delete-parameter"
+                icon={<OutlinedTrashAltIcon />}
+                iconPosition="left"
+                onClick={onParameterRemove(index)}
+              >
+                {i18n.delete}
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.css
@@ -18,3 +18,20 @@
   cursor: pointer;
   padding: 1em;
 }
+
+/** Styling .parameters-list container */
+.expression-container .function-expression > .table-component > table > thead > tr:last-of-type > th:last-of-type > .header-cell > .header-cell-info {
+  width: 100%;
+}
+
+.expression-container .function-expression .parameters-list {
+  cursor: pointer;
+  padding: 0.75em;
+}
+
+.expression-container .function-expression .parameters-list.empty-parameters {
+  color: gray;
+  font-style: italic;
+  font-weight: var(--pf-global--FontWeight--normal);
+  text-align: center;
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.css
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.expression-container .function-expression .selected-function-kind {
+  cursor: pointer;
+  padding: 1em;
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
@@ -16,7 +16,7 @@
 
 import "./FunctionExpression.css";
 import * as React from "react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useContext, useMemo, useRef, useState } from "react";
 import {
   DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH,
   FunctionKind,
@@ -33,6 +33,7 @@ import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { PopoverMenu } from "../PopoverMenu";
 import { Menu, MenuItem, MenuList } from "@patternfly/react-core";
 import * as _ from "lodash";
+import { BoxedExpressionGlobalContext } from "../../context";
 
 export const FunctionExpression: React.FunctionComponent<FunctionProps> = ({
   children,
@@ -48,8 +49,8 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = ({
 }) => {
   const { i18n } = useBoxedExpressionEditorI18n();
 
-  const functionExpressionRef = useRef<HTMLDivElement>(null);
-  const selectedFunctionKindRef = useRef<HTMLDivElement>(null);
+  const globalContext = useContext(BoxedExpressionGlobalContext);
+
   const columns = useRef<ColumnInstance[]>([
     {
       label: name,
@@ -98,14 +99,11 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = ({
     []
   );
 
-  const getFunctionKindSelectorArrowPlacement = useCallback(() => () => selectedFunctionKindRef.current!, []);
-
-  const renderFunctionKindSelectorPopover = useMemo(
-    () => (
+  const renderFunctionKindCell = useMemo(() => {
+    return (
       <PopoverMenu
         title={i18n.selectFunctionKind}
-        arrowPlacement={getFunctionKindSelectorArrowPlacement()}
-        appendTo={functionExpressionRef.current ?? undefined}
+        appendTo={globalContext.boxedExpressionEditorRef?.current ?? undefined}
         className="function-kind-popover"
         hasAutoWidth
         body={(hide: () => void) => (
@@ -113,35 +111,20 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = ({
             <MenuList>{renderFunctionKindItems()}</MenuList>
           </Menu>
         )}
-      />
-    ),
-    [
-      getFunctionKindSelectorArrowPlacement,
-      i18n.selectFunctionKind,
-      functionKindSelectionCallback,
-      renderFunctionKindItems,
-    ]
-  );
-
-  const renderSelectedFunctionKind = useMemo(() => {
-    return (
-      <div className="selected-function-kind" ref={selectedFunctionKindRef}>
-        {_.first(selectedFunctionKind)}
-      </div>
+      >
+        <div className="selected-function-kind">{_.first(selectedFunctionKind)}</div>
+      </PopoverMenu>
     );
-  }, [selectedFunctionKind]);
-
-  const renderFunctionKindCell = useMemo(() => {
-    return (
-      <React.Fragment>
-        {renderFunctionKindSelectorPopover}
-        {renderSelectedFunctionKind}
-      </React.Fragment>
-    );
-  }, [renderFunctionKindSelectorPopover, renderSelectedFunctionKind]);
+  }, [
+    functionKindSelectionCallback,
+    globalContext.boxedExpressionEditorRef,
+    i18n.selectFunctionKind,
+    renderFunctionKindItems,
+    selectedFunctionKind,
+  ]);
 
   return (
-    <div className={`function-expression ${uid}`} ref={functionExpressionRef}>
+    <div className={`function-expression ${uid}`}>
       <Table
         handlerConfiguration={[
           {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-export * from "./BoxedExpressionEditor";
-export * from "./BuiltinAggregation";
-export * from "./ContextEntry";
-export * from "./DataType";
-export * from "./DecisionTableRule";
-export * from "./ExpressionProps";
-export * from "./FunctionKind";
-export * from "./HitPolicy";
-export * from "./LogicType";
-export * from "./Table";
+import * as React from "react";
+import { FunctionProps } from "../../api";
+
+export const FunctionExpression: React.FunctionComponent<FunctionProps> = () => {
+  return <div>Function expression</div>;
+};

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
@@ -14,9 +14,150 @@
  * limitations under the License.
  */
 
+import "./FunctionExpression.css";
 import * as React from "react";
-import { FunctionProps } from "../../api";
+import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH,
+  FunctionKind,
+  FunctionProps,
+  LogicType,
+  resetEntry,
+  TableHeaderVisibility,
+  TableOperation,
+} from "../../api";
+import { Table } from "../Table";
+import { ColumnInstance, DataRecord } from "react-table";
+import { ContextEntryExpressionCell } from "../ContextExpression";
+import { useBoxedExpressionEditorI18n } from "../../i18n";
+import { PopoverMenu } from "../PopoverMenu";
+import { Menu, MenuItem, MenuList } from "@patternfly/react-core";
+import * as _ from "lodash";
 
-export const FunctionExpression: React.FunctionComponent<FunctionProps> = () => {
-  return <div>Function expression</div>;
+export const FunctionExpression: React.FunctionComponent<FunctionProps> = ({
+  children,
+  dataType,
+  formalParameters,
+  functionKind = FunctionKind.Feel,
+  isHeadless,
+  logicType,
+  name = "p-1",
+  onUpdatingNameAndDataType,
+  onUpdatingRecursiveExpression,
+  uid,
+}) => {
+  const { i18n } = useBoxedExpressionEditorI18n();
+
+  const functionExpressionRef = useRef<HTMLDivElement>(null);
+  const selectedFunctionKindRef = useRef<HTMLDivElement>(null);
+  const columns = useRef<ColumnInstance[]>([
+    {
+      label: name,
+      accessor: name,
+      dataType,
+      disableHandlerOnHeader: true,
+      columns: [
+        {
+          headerCellElement: <div>Parameters list</div>, //TODO parameters retrieved from `formalParameters`
+          accessor: "parameters",
+          disableHandlerOnHeader: true,
+          width: DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH, //TODO width as external param
+          minWidth: DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH,
+        },
+      ],
+    },
+  ] as ColumnInstance[]);
+
+  const [selectedFunctionKind, setSelectedFunctionKind] = useState(functionKind);
+  const [rows, setRows] = useState([{ entryExpression: { logicType: LogicType.LiteralExpression } } as DataRecord]); //TODO compose default row based on selected function kind
+
+  const getHeaderVisibility = useCallback(() => {
+    return isHeadless ? TableHeaderVisibility.LastLevel : TableHeaderVisibility.Full;
+  }, [isHeadless]);
+
+  const onFunctionKindSelect = useCallback((event: MouseEvent, itemId: string) => {
+    setSelectedFunctionKind(itemId as FunctionKind);
+    //TODO for first task, only FEEL (default) is available
+  }, []);
+
+  const functionKindSelectionCallback = useCallback(
+    (hide: () => void) => (event: MouseEvent, itemId: string) => {
+      onFunctionKindSelect(event, itemId);
+      hide();
+    },
+    [onFunctionKindSelect]
+  );
+
+  const renderFunctionKindItems = useCallback(
+    () =>
+      _.map(Object.values(FunctionKind), (key) => (
+        <MenuItem key={key} itemId={key}>
+          {key}
+        </MenuItem>
+      )),
+    []
+  );
+
+  const getFunctionKindSelectorArrowPlacement = useCallback(() => () => selectedFunctionKindRef.current!, []);
+
+  const renderFunctionKindSelectorPopover = useMemo(
+    () => (
+      <PopoverMenu
+        title={i18n.selectFunctionKind}
+        arrowPlacement={getFunctionKindSelectorArrowPlacement()}
+        appendTo={functionExpressionRef.current ?? undefined}
+        className="function-kind-popover"
+        hasAutoWidth
+        body={(hide: () => void) => (
+          <Menu onSelect={functionKindSelectionCallback(hide)}>
+            <MenuList>{renderFunctionKindItems()}</MenuList>
+          </Menu>
+        )}
+      />
+    ),
+    [
+      getFunctionKindSelectorArrowPlacement,
+      i18n.selectFunctionKind,
+      functionKindSelectionCallback,
+      renderFunctionKindItems,
+    ]
+  );
+
+  const renderSelectedFunctionKind = useMemo(() => {
+    return (
+      <div className="selected-function-kind" ref={selectedFunctionKindRef}>
+        {_.first(selectedFunctionKind)}
+      </div>
+    );
+  }, [selectedFunctionKind]);
+
+  const renderFunctionKindCell = useMemo(() => {
+    return (
+      <React.Fragment>
+        {renderFunctionKindSelectorPopover}
+        {renderSelectedFunctionKind}
+      </React.Fragment>
+    );
+  }, [renderFunctionKindSelectorPopover, renderSelectedFunctionKind]);
+
+  return (
+    <div className={`function-expression ${uid}`} ref={functionExpressionRef}>
+      <Table
+        handlerConfiguration={[
+          {
+            group: _.upperCase(i18n.function),
+            items: [{ name: i18n.rowOperations.clear, type: TableOperation.RowClear }],
+          },
+        ]}
+        columns={columns.current}
+        rows={rows}
+        onRowsUpdate={setRows}
+        headerLevels={1}
+        headerVisibility={getHeaderVisibility()}
+        controllerCell={renderFunctionKindCell}
+        defaultCell={{ parameters: ContextEntryExpressionCell }}
+        resetRowCustomFunction={useCallback(resetEntry, [])} //TODO check that when spreading expression definition, clear action gets immediately executed
+      />
+    </div>
+  );
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionKindSelector.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionKindSelector.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PopoverMenu } from "../PopoverMenu";
+import { Menu, MenuItem, MenuList } from "@patternfly/react-core";
+import * as _ from "lodash";
+import * as React from "react";
+import { useCallback, useContext } from "react";
+import { useBoxedExpressionEditorI18n } from "../../i18n";
+import { BoxedExpressionGlobalContext } from "../../context";
+import { FunctionKind } from "../../api";
+
+export interface FunctionKindSelectorProps {
+  /** Pre-selected function kind */
+  selectedFunctionKind: FunctionKind;
+  /** Callback invoked when function kind selection changes */
+  onFunctionKindSelect: (functionKind: FunctionKind) => void;
+}
+
+export const FunctionKindSelector: React.FunctionComponent<FunctionKindSelectorProps> = ({
+  selectedFunctionKind,
+  onFunctionKindSelect,
+}) => {
+  const { i18n } = useBoxedExpressionEditorI18n();
+
+  const globalContext = useContext(BoxedExpressionGlobalContext);
+
+  const functionKindSelectionCallback = useCallback(
+    (hide: () => void) => (event: MouseEvent, itemId: string) => {
+      onFunctionKindSelect(itemId as FunctionKind);
+      hide();
+    },
+    [onFunctionKindSelect]
+  );
+
+  const renderFunctionKindItems = useCallback(
+    () =>
+      _.map(Object.values(FunctionKind), (key) => (
+        <MenuItem key={key} itemId={key} data-ouia-component-id={key}>
+          {key}
+        </MenuItem>
+      )),
+    []
+  );
+
+  return (
+    <PopoverMenu
+      title={i18n.selectFunctionKind}
+      appendTo={globalContext.boxedExpressionEditorRef?.current ?? undefined}
+      className="function-kind-popover"
+      hasAutoWidth
+      body={(hide: () => void) => (
+        <Menu onSelect={functionKindSelectionCallback(hide)}>
+          <MenuList>{renderFunctionKindItems()}</MenuList>
+        </Menu>
+      )}
+    >
+      <div className="selected-function-kind">{_.first(selectedFunctionKind)}</div>
+    </PopoverMenu>
+  );
+};

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/index.ts
@@ -15,3 +15,4 @@
  */
 
 export * from "./FunctionExpression";
+export * from "./FunctionKindSelector";

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,4 @@
  * limitations under the License.
  */
 
-export * from "./BoxedExpressionEditor";
-export * from "./BuiltinAggregation";
-export * from "./ContextEntry";
-export * from "./DataType";
-export * from "./DecisionTableRule";
-export * from "./ExpressionProps";
-export * from "./FunctionKind";
-export * from "./HitPolicy";
-export * from "./LogicType";
-export * from "./Table";
+export * from "./FunctionExpression";

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/index.ts
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
+export * from "./EditParameters";
 export * from "./FunctionExpression";
 export * from "./FunctionKindSelector";

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
@@ -147,7 +147,7 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
 
   const onColumnsUpdate = useCallback(
     ([expressionColumn]: [ColumnInstance]) => {
-      onUpdatingNameAndDataType?.(expressionColumn.label, expressionColumn.dataType);
+      onUpdatingNameAndDataType?.(expressionColumn.label as string, expressionColumn.dataType);
       infoWidth.current = _.find(expressionColumn.columns, { accessor: "entryInfo" })?.width as number;
       expressionWidth.current = _.find(expressionColumn.columns, { accessor: "entryExpression" })?.width as number;
       const [updatedExpressionColumn] = columns.current;

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
@@ -19,9 +19,11 @@ import * as React from "react";
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from "react";
 import {
   ContextEntries,
+  ContextEntryRecord,
   DataType,
   DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH,
   DEFAULT_ENTRY_INFO_MIN_WIDTH,
+  EntryInfo,
   generateNextAvailableEntryName,
   getEntryKey,
   getHandlerConfiguration,
@@ -162,7 +164,10 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
   const onRowAdding = useCallback(
     () => ({
       entryInfo: {
-        name: generateNextAvailableEntryName(rows as ContextEntries, "p"),
+        name: generateNextAvailableEntryName(
+          _.map(rows, (row: ContextEntryRecord) => row.entryInfo) as EntryInfo[],
+          "p"
+        ),
         dataType: DEFAULT_PARAMETER_DATA_TYPE,
       },
       entryExpression: {},

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
@@ -16,7 +16,7 @@
 
 import "./LiteralExpression.css";
 import * as React from "react";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DataType, ExpressionProps, LiteralExpressionProps, LogicType } from "../../api";
 import { TextArea } from "@patternfly/react-core";
 import { EditExpressionMenu, EXPRESSION_NAME } from "../EditExpressionMenu";
@@ -35,16 +35,16 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
   const HEADER_WIDTH = 250;
   const HEADER_HEIGHT = 40;
 
-  const expressionName = useRef<string>(name);
-  const expressionDataType = useRef<DataType>(dataType);
+  const [expressionName, setExpressionName] = useState<string>(name);
+  const [expressionDataType, setExpressionDataType] = useState<DataType>(dataType);
   const literalExpressionContent = useRef<string>(content);
   const literalExpressionWidth = useRef<number>(width || HEADER_WIDTH);
 
   const spreadLiteralExpressionDefinition = useCallback(() => {
     const expressionDefinition: LiteralExpressionProps = {
       uid,
-      name: expressionName.current,
-      dataType: expressionDataType.current,
+      name: expressionName,
+      dataType: expressionDataType,
       logicType: LogicType.LiteralExpression,
       content: literalExpressionContent.current,
       ...(!isHeadless && literalExpressionWidth.current !== HEADER_WIDTH
@@ -54,12 +54,12 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
     isHeadless
       ? onUpdatingRecursiveExpression?.(expressionDefinition)
       : window.beeApi?.broadcastLiteralExpressionDefinition?.(expressionDefinition);
-  }, [isHeadless, onUpdatingRecursiveExpression, uid]);
+  }, [expressionDataType, expressionName, isHeadless, onUpdatingRecursiveExpression, uid]);
 
   const onExpressionUpdate = useCallback(
     ({ dataType = DataType.Undefined, name = EXPRESSION_NAME }: ExpressionProps) => {
-      expressionName.current = name;
-      expressionDataType.current = dataType;
+      setExpressionName(name);
+      setExpressionDataType(dataType);
       onUpdatingNameAndDataType?.(name, dataType);
       spreadLiteralExpressionDefinition();
     },
@@ -102,19 +102,19 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
       <div className="literal-expression-header">
         {renderElementWithResizeHandler(
           <EditExpressionMenu
-            selectedExpressionName={expressionName.current}
-            selectedDataType={expressionDataType.current}
+            selectedExpressionName={expressionName}
+            selectedDataType={expressionDataType}
             onExpressionUpdate={onExpressionUpdate}
           >
             <div className="expression-info">
-              <p className="expression-name pf-u-text-truncate">{expressionName.current}</p>
-              <p className="expression-data-type pf-u-text-truncate">({expressionDataType.current})</p>
+              <p className="expression-name pf-u-text-truncate">{expressionName}</p>
+              <p className="expression-data-type pf-u-text-truncate">({expressionDataType})</p>
             </div>
           </EditExpressionMenu>
         )}
       </div>
     );
-  }, [onExpressionUpdate, renderElementWithResizeHandler]);
+  }, [expressionDataType, expressionName, onExpressionUpdate, renderElementWithResizeHandler]);
 
   const getBodyContent = useMemo(
     () => (

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.tsx
@@ -22,6 +22,8 @@ import {
   DataType,
   DecisionTableProps,
   ExpressionProps,
+  FunctionKind,
+  FunctionProps,
   InvocationProps,
   ListProps,
   LiteralExpressionProps,
@@ -42,6 +44,7 @@ import { BoxedExpressionGlobalContext } from "../../context";
 import { DecisionTableExpression } from "../DecisionTableExpression";
 import { ListExpression } from "../ListExpression";
 import { InvocationExpression } from "../InvocationExpression";
+import { FunctionExpression } from "../FunctionExpression";
 
 export interface LogicTypeSelectorProps {
   /** Expression properties */
@@ -111,6 +114,7 @@ export const LogicTypeSelector: React.FunctionComponent<LogicTypeSelectorProps> 
       case LogicType.List:
         return <ListExpression {...(expression as ListProps)} />;
       case LogicType.Function:
+        return <FunctionExpression {..._.defaults(expression, { functionKind: FunctionKind.Feel } as FunctionProps)} />;
       default:
         return expression.logicType;
     }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/PopoverMenu.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/PopoverMenu.css
@@ -29,7 +29,6 @@
   border-radius: 0;
   color: #4d5258;
   font-weight: 700;
-  min-height: 34px;
   margin: 0;
   padding: 8px 14px;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/PopoverMenu.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/PopoverMenu/PopoverMenu.tsx
@@ -33,6 +33,8 @@ export interface PopoverMenuProps {
   className?: string;
   /** True to have width automatically computed */
   hasAutoWidth?: boolean;
+  /** Popover min width */
+  minWidth?: string;
 }
 
 export const PopoverMenu: React.FunctionComponent<PopoverMenuProps> = ({
@@ -43,12 +45,14 @@ export const PopoverMenu: React.FunctionComponent<PopoverMenuProps> = ({
   appendTo,
   className,
   hasAutoWidth,
+  minWidth,
 }: PopoverMenuProps) => {
   return (
     <Popover
       data-ouia-component-id="expression-popover-menu"
       className={`popover-menu-selector${className ? " " + className : ""}`}
       hasAutoWidth={hasAutoWidth}
+      minWidth={minWidth}
       position="bottom"
       distance={0}
       id="menu-selector"

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.tsx
@@ -118,6 +118,12 @@ export const Table: React.FunctionComponent<TableProps> = ({
     setCurrentControllerCell(controllerCell);
   }, [controllerCell, generateNumberOfRowsColumn]);
 
+  useEffect(() => {
+    tableColumns.current = generateNumberOfRowsColumn(currentControllerCell, columns);
+    // Watching for external changes of the columns
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [columns]);
+
   const onColumnsUpdateCallback = useCallback(
     (columns: Column[]) => {
       tableColumns.current = columns;

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.tsx
@@ -28,7 +28,7 @@ import { TableComposable } from "@patternfly/react-table";
 import * as React from "react";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { EditableCell } from "./EditableCell";
-import { TableOperation, TableProps } from "../../api";
+import { TableHeaderVisibility, TableOperation, TableProps } from "../../api";
 import * as _ from "lodash";
 import { TableBody } from "./TableBody";
 import { TableHandler } from "./TableHandler";
@@ -36,6 +36,8 @@ import { TableHeader } from "./TableHeader";
 import { BoxedExpressionGlobalContext } from "../../context";
 
 export const NO_TABLE_CONTEXT_MENU_CLASS = "no-table-context-menu";
+const NUMBER_OF_ROWS_COLUMN = "#";
+const NUMBER_OF_ROWS_SUBCOLUMN = "0";
 
 export const Table: React.FunctionComponent<TableProps> = ({
   tableId,
@@ -45,6 +47,7 @@ export const Table: React.FunctionComponent<TableProps> = ({
   onColumnsUpdate,
   onRowsUpdate,
   onRowAdding = () => ({}),
+  controllerCell = NUMBER_OF_ROWS_COLUMN,
   defaultCell,
   rows,
   columns,
@@ -56,45 +59,51 @@ export const Table: React.FunctionComponent<TableProps> = ({
   getColumnKey = (column) => column.id as string,
   resetRowCustomFunction,
 }: TableProps) => {
-  const NUMBER_OF_ROWS_COLUMN = "#";
-  const NUMBER_OF_ROWS_SUBCOLUMN = "0";
-
   const tableRef = useRef<HTMLTableElement>(null);
 
   const globalContext = useContext(BoxedExpressionGlobalContext);
 
-  const generateNumberOfRowsSubColumnRecursively: (column: ColumnInstance, headerLevels: number) => void = (
-    column,
-    headerLevels
-  ) => {
-    if (headerLevels > 0) {
-      _.assign(column, {
-        columns: [
-          {
-            label: NUMBER_OF_ROWS_SUBCOLUMN,
-            accessor: NUMBER_OF_ROWS_SUBCOLUMN,
-            minWidth: 60,
-            width: 60,
-            disableResizing: true,
-            isCountColumn: true,
-            hideFilter: true,
-          },
-        ],
-      });
+  const [currentControllerCell, setCurrentControllerCell] = useState(controllerCell);
 
-      generateNumberOfRowsSubColumnRecursively(column.columns[0], headerLevels - 1);
-    }
-  };
+  const generateNumberOfRowsSubColumnRecursively: (column: ColumnInstance, headerLevels: number) => void = useCallback(
+    (column, headerLevels) => {
+      if (headerLevels > 0) {
+        _.assign(column, {
+          columns: [
+            {
+              label: headerVisibility === TableHeaderVisibility.Full ? NUMBER_OF_ROWS_SUBCOLUMN : currentControllerCell,
+              accessor: NUMBER_OF_ROWS_SUBCOLUMN,
+              minWidth: 60,
+              width: 60,
+              disableResizing: true,
+              isCountColumn: true,
+              hideFilter: true,
+            },
+          ],
+        });
 
-  const numberOfRowsColumn = {
-    label: NUMBER_OF_ROWS_COLUMN,
-    accessor: NUMBER_OF_ROWS_COLUMN,
-    width: 60,
-    minWidth: 60,
-    isCountColumn: true,
-  } as ColumnInstance;
-  generateNumberOfRowsSubColumnRecursively(numberOfRowsColumn, headerLevels);
-  const tableColumns = useRef<Column[]>([numberOfRowsColumn, ...columns]);
+        generateNumberOfRowsSubColumnRecursively(column.columns[0], headerLevels - 1);
+      }
+    },
+    [currentControllerCell, headerVisibility]
+  );
+
+  const generateNumberOfRowsColumn = useCallback(
+    (currentControllerCell: string | JSX.Element, columns: Column[]) => {
+      const numberOfRowsColumn = {
+        label: currentControllerCell,
+        accessor: NUMBER_OF_ROWS_COLUMN,
+        width: 60,
+        minWidth: 60,
+        isCountColumn: true,
+      } as ColumnInstance;
+      generateNumberOfRowsSubColumnRecursively(numberOfRowsColumn, headerLevels);
+      return [numberOfRowsColumn, ...columns];
+    },
+    [generateNumberOfRowsSubColumnRecursively, headerLevels]
+  );
+
+  const tableColumns = useRef<Column[]>(generateNumberOfRowsColumn(currentControllerCell, columns));
   const tableRows = useRef<DataRecord[]>(rows);
   const [showTableHandler, setShowTableHandler] = useState(false);
   const [tableHandlerTarget, setTableHandlerTarget] = useState(document.body);
@@ -103,6 +112,11 @@ export const Table: React.FunctionComponent<TableProps> = ({
   );
   const [lastSelectedColumnIndex, setLastSelectedColumnIndex] = useState(-1);
   const [lastSelectedRowIndex, setLastSelectedRowIndex] = useState(-1);
+
+  useEffect(() => {
+    tableColumns.current = generateNumberOfRowsColumn(controllerCell, tableColumns.current.slice(1));
+    setCurrentControllerCell(controllerCell);
+  }, [controllerCell, generateNumberOfRowsColumn]);
 
   const onColumnsUpdateCallback = useCallback(
     (columns: Column[]) => {
@@ -265,7 +279,7 @@ export const Table: React.FunctionComponent<TableProps> = ({
           {children}
         </TableBody>
       </TableComposable>
-      {showTableHandler ? (
+      {showTableHandler && handlerConfiguration ? (
         <TableHandler
           tableColumns={tableColumns}
           columnPrefix={columnPrefix}

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/BoxedExpressionEditorI18n.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/BoxedExpressionEditorI18n.ts
@@ -50,6 +50,7 @@ interface BoxedExpressionEditorDictionary extends ReferenceDictionary<BoxedExpre
     insertBelow: string;
   };
   selectExpression: string;
+  selectFunctionKind: string;
   selectLogicType: string;
 }
 

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/BoxedExpressionEditorI18n.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/BoxedExpressionEditorI18n.ts
@@ -18,6 +18,7 @@ import { ReferenceDictionary } from "@kogito-tooling/i18n/dist/core";
 import { CommonI18n } from "@kogito-tooling/i18n-common-dictionary";
 
 interface BoxedExpressionEditorDictionary extends ReferenceDictionary<BoxedExpressionEditorDictionary> {
+  addParameter: string;
   choose: string;
   columns: string;
   columnOperations: {
@@ -33,8 +34,10 @@ interface BoxedExpressionEditorDictionary extends ReferenceDictionary<BoxedExpre
   editContextEntry: string;
   editExpression: string;
   editParameter: string;
+  editParameters: string;
   editRelation: string;
   enterFunction: string;
+  delete: string;
   function: string;
   invocation: string;
   list: string;

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
@@ -19,6 +19,7 @@ import { en as en_common } from "@kogito-tooling/i18n-common-dictionary";
 
 export const en: BoxedExpressionEditorI18n = {
   ...en_common,
+  addParameter: "Add parameter",
   choose: "Choose...",
   clear: "Clear",
   columnOperations: {
@@ -31,9 +32,11 @@ export const en: BoxedExpressionEditorI18n = {
   contextEntry: "CONTEXT ENTRY",
   dataType: "Data Type",
   decisionTable: "Decision Table",
+  delete: "Delete",
   editContextEntry: "Edit Context Entry",
   editExpression: "Edit Expression",
   editParameter: "Edit Parameter",
+  editParameters: "Edit parameters",
   editRelation: "Edit Relation",
   enterFunction: "Enter function",
   function: "Function",

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
@@ -51,5 +51,6 @@ export const en: BoxedExpressionEditorI18n = {
   },
   rows: "ROWS",
   selectExpression: "Select expression",
+  selectFunctionKind: "Select Function Kind",
   selectLogicType: "Select logic type",
 };


### PR DESCRIPTION
This PR contains both `FunctionExpression` container and support for the `Feel` Function kind.
Other function kinds (`PMML` and `Java`) will be covered in KOGITO-3651 and KOGITO-3636.
It is possible to access the deployed version [there](https://vpellegrino.github.io/kie-wb-common/).