### PR TITLE
KOGITO-3636: Create "JavaFunction" component

### DIFF
--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import {
   activateSelector,
   EDIT_EXPRESSION_DATA_TYPE,
@@ -288,4 +288,91 @@ describe("FunctionExpression tests", () => {
       ).toBeTruthy();
     });
   });
+
+  describe("JAVA Function Kind", () => {
+    test("should show, by default, an entry with a context table, containing two entries: class and method", () => {
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <FunctionExpression logicType={LogicType.Function} functionKind={FunctionKind.Java} formalParameters={[]} />
+        ).wrapper
+      );
+
+      expect(container.querySelector(".function-expression table tbody td.data-cell")).toBeVisible();
+      expect(container.querySelector(".function-expression table tbody td.data-cell .context-expression")).toBeTruthy();
+      expect(
+        container.querySelectorAll(
+          ".function-expression table tbody td.data-cell .context-expression .context-entry-info-cell"
+        )
+      ).toHaveLength(2);
+      expect(
+        container.querySelectorAll(
+          ".function-expression table tbody td.data-cell .context-expression .context-entry-info-cell"
+        )[0]
+      ).toContainHTML("class");
+      expect(
+        container.querySelectorAll(
+          ".function-expression table tbody td.data-cell .context-expression .context-entry-info-cell"
+        )[1]
+      ).toContainHTML("method");
+    });
+
+    test("should show an entry corresponding to the passed class and method values", () => {
+      const classValue = "class value";
+      const methodValue = "method value";
+
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <FunctionExpression
+            logicType={LogicType.Function}
+            functionKind={FunctionKind.Java}
+            formalParameters={[]}
+            class={classValue}
+            method={methodValue}
+          />
+        ).wrapper
+      );
+
+      expect(
+        container.querySelectorAll(
+          ".function-expression table tbody td.data-cell .context-expression .context-entry-expression-cell"
+        )
+      ).toHaveLength(2);
+      expect(
+        container.querySelectorAll(
+          ".function-expression table tbody td.data-cell .context-expression .context-entry-expression-cell"
+        )[0]
+      ).toContainHTML(classValue);
+      expect(
+        container.querySelectorAll(
+          ".function-expression table tbody td.data-cell .context-expression .context-entry-expression-cell"
+        )[1]
+      ).toContainHTML(methodValue);
+    });
+  });
+
+  function mockBroadcastDefinition(mockedBroadcastDefinition: jest.Mock) {
+    window.beeApi = _.extend(window.beeApi || {}, {
+      broadcastFunctionExpressionDefinition: (definition: FunctionProps) => mockedBroadcastDefinition(definition),
+    });
+  }
+
+  async function clearTableRow(container: Element, baseElement: Element) {
+    await act(async () => {
+      fireEvent.contextMenu(
+        container.querySelector(".function-expression table tbody td.counter-cell") as HTMLTableElement
+      );
+      await flushPromises();
+      await jest.runAllTimers();
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        baseElement.querySelector(
+          "[data-ouia-component-id='expression-table-handler-menu-Clear'] button"
+        )! as HTMLButtonElement
+      );
+      await flushPromises();
+      await jest.runAllTimers();
+    });
+  }
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
@@ -62,6 +62,30 @@ describe("FunctionExpression tests", () => {
     );
   });
 
+  test("should reset function kind to FEEL, when resetting table row", async () => {
+    const mockedBroadcastDefinition = jest.fn();
+    mockBroadcastDefinition(mockedBroadcastDefinition);
+    const { container, baseElement } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <FunctionExpression logicType={LogicType.Function} functionKind={FunctionKind.Java} formalParameters={[]} />
+      ).wrapper
+    );
+
+    await clearTableRow(container, baseElement);
+
+    expect(mockedBroadcastDefinition).toHaveBeenLastCalledWith({
+      dataType: undefined,
+      expression: {
+        uid: "id1",
+      },
+      formalParameters: [],
+      functionKind: "FEEL",
+      logicType: "Function",
+      name: "p-1",
+      uid: undefined,
+    });
+  });
+
   describe("Formal Parameters", () => {
     beforeEach(() => {
       jest.clearAllTimers();
@@ -219,12 +243,6 @@ describe("FunctionExpression tests", () => {
         logicType: "Function",
         name: "p-1",
         uid: undefined,
-      });
-    }
-
-    function mockBroadcastDefinition(mockedBroadcastDefinition: jest.Mock) {
-      window.beeApi = _.extend(window.beeApi || {}, {
-        broadcastFunctionExpressionDefinition: (definition: FunctionProps) => mockedBroadcastDefinition(definition),
       });
     }
   });

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ContextEntry.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ContextEntry.ts
@@ -33,7 +33,7 @@ export interface ContextEntryRecord {
   /** Entry expression */
   entryExpression: ExpressionProps;
   /** Label used for the popover triggered when editing info section */
-  editInfoPopoverLabel: string;
+  editInfoPopoverLabel?: string;
   /** Callback to be invoked on expression resetting */
   onExpressionResetting?: () => void;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -34,10 +34,12 @@ export interface ExpressionProps {
   onUpdatingNameAndDataType?: (updatedName: string, updatedDataType: DataType) => void;
   /** Logic type should not be defined at this stage */
   logicType?: LogicType;
-  /** True to have no header for this specific expression component, used in a recursive expression */
+  /** True, to have no header for this specific expression component, used in a recursive expression */
   isHeadless?: boolean;
   /** When a component is headless, it will call this function to pass its most updated expression definition */
   onUpdatingRecursiveExpression?: (expression: ExpressionProps) => void;
+  /** True, to have no clear action rendered for this specific expression */
+  noClearAction?: boolean;
 }
 
 export interface LiteralExpressionProps extends ExpressionProps {

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -65,10 +65,14 @@ export interface ContextProps extends ExpressionProps {
   contextEntries?: ContextEntries;
   /** Context result */
   result?: ExpressionProps;
+  /** False, to avoid the rendering of the result section */
+  renderResult?: boolean;
   /** Entry info width */
   entryInfoWidth?: number;
   /** Entry expression width */
   entryExpressionWidth?: number;
+  /** True, to avoid the presence of table menu handler */
+  noHandlerMenu?: boolean;
 }
 
 export interface DecisionTableProps extends ExpressionProps {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextEntryExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextEntryExpression.tsx
@@ -38,12 +38,11 @@ export const ContextEntryExpression: React.FunctionComponent<ContextEntryExpress
 
   const entryExpression = useRef(expression);
 
-  const expressionChangedExternally = expression.logicType === undefined;
   useEffect(() => {
     entryExpression.current = _.omit(expression, "isHeadless");
-    // Every time, for an expression, its logic type is undefined, it means that corresponding entry has been just added
+    // Every time, for an expression, its logic type changes, it means that corresponding entry has been just updated
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [expressionChangedExternally]);
+  }, [expression.logicType]);
 
   const getLogicTypeSelectorRef = useCallback(() => {
     return expressionContainerRef.current!;

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextEntryExpressionCell.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextEntryExpressionCell.tsx
@@ -38,13 +38,12 @@ export const ContextEntryExpressionCell: React.FunctionComponent<ContextEntryExp
     ...contextEntry.entryExpression,
   } as ExpressionProps);
 
-  const expressionChangedExternally = contextEntry.entryExpression.logicType === undefined;
   useEffect(() => {
     entryExpression.current = contextEntry.entryExpression;
     onRowUpdate(index, { ...contextEntry, entryExpression: entryExpression.current });
-    // Every time, for an expression, its logic type is undefined, it means that corresponding entry has been just added
+    // Every time, for an expression, its logic type changes, it means that corresponding entry has been just updated
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [expressionChangedExternally]);
+  }, [contextEntry.entryExpression.logicType]);
 
   const onUpdatingRecursiveExpression = useCallback((expression: ExpressionProps) => {
     entryExpression.current = expression;

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextEntryInfo.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextEntryInfo.css
@@ -19,8 +19,11 @@
 }
 
 .expression-container .entry-info .entry-definition {
-  cursor: pointer;
   padding: 0.25em;
+}
+
+.expression-container .entry-info .entry-definition.with-popover-menu {
+  cursor: pointer;
 }
 
 .expression-container .entry-info .entry-definition .entry-name {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextEntryInfo.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextEntryInfo.tsx
@@ -16,7 +16,7 @@
 
 import "./ContextEntryInfo.css";
 import * as React from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { EditExpressionMenu } from "../EditExpressionMenu";
 import { DataType } from "../../api";
 
@@ -28,7 +28,7 @@ export interface ContextEntryInfoProps {
   /** Callback to be executed when name or dataType get updated */
   onContextEntryUpdate: (name: string, dataType: DataType) => void;
   /** Label used for the popover triggered when editing info section */
-  editInfoPopoverLabel: string;
+  editInfoPopoverLabel?: string;
 }
 
 export const ContextEntryInfo: React.FunctionComponent<ContextEntryInfoProps> = ({
@@ -58,23 +58,37 @@ export const ContextEntryInfo: React.FunctionComponent<ContextEntryInfoProps> = 
     [onContextEntryUpdate]
   );
 
-  return (
-    <div className="entry-info">
+  const renderEntryDefinition = useCallback(
+    (additionalCssClass?: string) => (
+      <div className={`entry-definition ${additionalCssClass}`}>
+        <p className="entry-name pf-u-text-truncate" title={entryName}>
+          {entryName}
+        </p>
+        <p className="entry-data-type pf-u-text-truncate" title={entryDataType}>
+          ({entryDataType})
+        </p>
+      </div>
+    ),
+    [entryDataType, entryName]
+  );
+
+  const renderEntryDefinitionWithPopoverMenu = useMemo(
+    () => (
       <EditExpressionMenu
         title={editInfoPopoverLabel}
         selectedExpressionName={entryName}
         selectedDataType={entryDataType}
         onExpressionUpdate={onEntryNameOrDataTypeUpdate}
       >
-        <div className="entry-definition">
-          <p className="entry-name pf-u-text-truncate" title={entryName}>
-            {entryName}
-          </p>
-          <p className="entry-data-type pf-u-text-truncate" title={entryDataType}>
-            ({entryDataType})
-          </p>
-        </div>
+        {renderEntryDefinition("with-popover-menu")}
       </EditExpressionMenu>
+    ),
+    [editInfoPopoverLabel, entryDataType, entryName, onEntryNameOrDataTypeUpdate, renderEntryDefinition]
+  );
+
+  return (
+    <div className="entry-info">
+      {editInfoPopoverLabel ? renderEntryDefinitionWithPopoverMenu : renderEntryDefinition()}
     </div>
   );
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
@@ -51,10 +51,12 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
   onUpdatingNameAndDataType,
   contextEntries,
   result = {} as ExpressionProps,
+  renderResult = true,
   entryInfoWidth = DEFAULT_ENTRY_INFO_MIN_WIDTH,
   entryExpressionWidth = DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH,
   isHeadless = false,
   onUpdatingRecursiveExpression,
+  noHandlerMenu = false,
 }) => {
   const { i18n } = useBoxedExpressionEditorI18n();
 
@@ -165,12 +167,20 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
         onColumnsUpdate={onColumnsUpdate}
         onRowAdding={onRowAdding}
         onRowsUpdate={setRows}
-        handlerConfiguration={getHandlerConfiguration(i18n, i18n.contextEntry)}
+        handlerConfiguration={noHandlerMenu ? undefined : getHandlerConfiguration(i18n, i18n.contextEntry)}
         getRowKey={useCallback(getEntryKey, [])}
         resetRowCustomFunction={useCallback(resetEntry, [])}
       >
-        <div className="context-result">{`<result>`}</div>
-        <ContextEntryExpression expression={resultExpression} onUpdatingRecursiveExpression={setResultExpression} />
+        {renderResult
+          ? [
+              <div key="context-result" className="context-result">{`<result>`}</div>,
+              <ContextEntryExpression
+                key="context-expression"
+                expression={resultExpression}
+                onUpdatingRecursiveExpression={setResultExpression}
+              />,
+            ]
+          : undefined}
       </Table>
     </div>
   );

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
@@ -137,6 +137,7 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
             {
               entryExpression: {
                 logicType: LogicType.Context,
+                noClearAction: true,
                 renderResult: false,
                 noHandlerMenu: true,
                 contextEntries: extractContextEntriesFromJavaProps(javaProps),

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
@@ -18,11 +18,15 @@ import "./FunctionExpression.css";
 import * as React from "react";
 import { PropsWithChildren, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import {
+  ContextProps,
+  DataType,
   DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH,
   ExpressionProps,
   FeelFunctionProps,
   FunctionKind,
   FunctionProps,
+  JavaFunctionProps,
+  LiteralExpressionProps,
   LogicType,
   resetEntry,
   TableHeaderVisibility,
@@ -99,11 +103,47 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
     [props.dataType, headerCellElement, name]
   );
 
+  const extractContextEntriesFromJavaProps = useCallback(
+    (javaProps: JavaFunctionProps & { children?: React.ReactNode }) => {
+      return [
+        {
+          entryInfo: { name: i18n.class, dataType: DataType.String },
+          entryExpression: {
+            noClearAction: true,
+            logicType: LogicType.LiteralExpression,
+            content: javaProps.class,
+          } as LiteralExpressionProps,
+        },
+        {
+          entryInfo: { name: i18n.methodSignature, dataType: DataType.String },
+          entryExpression: {
+            noClearAction: true,
+            logicType: LogicType.LiteralExpression,
+            content: javaProps.method,
+          } as LiteralExpressionProps,
+        },
+      ];
+    },
+    [i18n.class, i18n.methodSignature]
+  );
+
   const evaluateRows = useCallback(
     (functionKind: FunctionKind) => {
-      //TODO for first task, only FEEL (default) is available
+      //TODO PMML kind is still missing
       switch (functionKind) {
-        case FunctionKind.Java:
+        case FunctionKind.Java: {
+          const javaProps: PropsWithChildren<JavaFunctionProps> = props as PropsWithChildren<JavaFunctionProps>;
+          return [
+            {
+              entryExpression: {
+                logicType: LogicType.Context,
+                renderResult: false,
+                noHandlerMenu: true,
+                contextEntries: extractContextEntriesFromJavaProps(javaProps),
+              },
+            } as DataRecord,
+          ];
+        }
         case FunctionKind.Pmml:
         case FunctionKind.Feel:
         default: {
@@ -114,7 +154,7 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
         }
       }
     },
-    [props]
+    [extractContextEntriesFromJavaProps, props]
   );
 
   const width = useRef<number>(parametersWidth);
@@ -124,9 +164,16 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
 
   const extendDefinitionBasedOnFunctionKind = useCallback(
     (definition: FunctionProps, functionKind: FunctionKind) => {
-      //TODO for first task, only FEEL (default) is available
+      //TODO PMML kind is still missing
       switch (functionKind) {
-        case FunctionKind.Java:
+        case FunctionKind.Java: {
+          const contextProps = _.first(rows)?.entryExpression as ContextProps;
+          const className =
+            (_.nth(contextProps.contextEntries, 0)?.entryExpression as LiteralExpressionProps).content || "";
+          const methodName =
+            (_.nth(contextProps.contextEntries, 1)?.entryExpression as LiteralExpressionProps).content || "";
+          return _.extend(definition, { class: className, method: methodName });
+        }
         case FunctionKind.Pmml:
         case FunctionKind.Feel:
         default: {
@@ -161,9 +208,14 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
     return props.isHeadless ? TableHeaderVisibility.LastLevel : TableHeaderVisibility.Full;
   }, [props.isHeadless]);
 
-  const onFunctionKindSelect = useCallback((itemId: string) => {
-    setSelectedFunctionKind(itemId as FunctionKind);
-  }, []);
+  const onFunctionKindSelect = useCallback(
+    (itemId: string) => {
+      const kind = itemId as FunctionKind;
+      setSelectedFunctionKind(kind);
+      setRows(evaluateRows(kind));
+    },
+    [evaluateRows]
+  );
 
   const onColumnsUpdate = useCallback(
     ([expressionColumn]: [ColumnInstance]) => {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
@@ -170,9 +170,9 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
         case FunctionKind.Java: {
           const contextProps = _.first(rows)?.entryExpression as ContextProps;
           const className =
-            (_.nth(contextProps.contextEntries, 0)?.entryExpression as LiteralExpressionProps).content || "";
+            (_.nth(contextProps.contextEntries, 0)?.entryExpression as LiteralExpressionProps)?.content || "";
           const methodName =
-            (_.nth(contextProps.contextEntries, 1)?.entryExpression as LiteralExpressionProps).content || "";
+            (_.nth(contextProps.contextEntries, 1)?.entryExpression as LiteralExpressionProps)?.content || "";
           return _.extend(definition, { class: className, method: methodName });
         }
         case FunctionKind.Pmml:
@@ -213,7 +213,12 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
     (itemId: string) => {
       const kind = itemId as FunctionKind;
       setSelectedFunctionKind(kind);
-      setRows(evaluateRows(kind));
+      // Resetting table content, every time function kind gets selected
+      setRows([{ entryExpression: { logicType: LogicType.Undefined } }]);
+      // Need to wait for the next rendering cycle before setting the correct table rows, based on function kind
+      setTimeout(() => {
+        setRows(evaluateRows(kind));
+      }, 0);
     },
     [evaluateRows]
   );

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
@@ -189,6 +189,11 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [parameters]);
 
+  const resetRowCustomFunction = useCallback((row) => {
+    setSelectedFunctionKind(FunctionKind.Feel);
+    return resetEntry(row);
+  }, []);
+
   return (
     <div className={`function-expression ${props.uid}`}>
       <Table
@@ -211,7 +216,7 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
           />
         }
         defaultCell={{ parameters: ContextEntryExpressionCell }}
-        resetRowCustomFunction={useCallback(resetEntry, [])}
+        resetRowCustomFunction={resetRowCustomFunction}
       />
     </div>
   );

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.tsx
@@ -207,7 +207,7 @@ export const LogicTypeSelector: React.FunctionComponent<LogicTypeSelectorProps> 
     >
       {logicTypeSelected ? renderExpression : i18n.selectExpression}
       {!logicTypeSelected ? buildLogicSelectorMenu() : null}
-      {contextMenuVisibility ? buildContextMenu() : null}
+      {!selectedExpression.noClearAction && contextMenuVisibility ? buildContextMenu() : null}
     </div>
   );
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.tsx
@@ -124,6 +124,12 @@ export const Table: React.FunctionComponent<TableProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [columns]);
 
+  useEffect(() => {
+    tableRows.current = rows;
+    // Watching for external changes of the rows
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rows]);
+
   const onColumnsUpdateCallback = useCallback(
     (columns: Column[]) => {
       tableColumns.current = columns;

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/BoxedExpressionEditorI18n.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/BoxedExpressionEditorI18n.ts
@@ -26,6 +26,7 @@ interface BoxedExpressionEditorDictionary extends ReferenceDictionary<BoxedExpre
     insertLeft: string;
     insertRight: string;
   };
+  class: string;
   clear: string;
   context: string;
   contextEntry: string;
@@ -42,6 +43,7 @@ interface BoxedExpressionEditorDictionary extends ReferenceDictionary<BoxedExpre
   invocation: string;
   list: string;
   literalExpression: string;
+  methodSignature: string;
   name: string;
   parameters: string;
   relation: string;

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
@@ -21,6 +21,7 @@ export const en: BoxedExpressionEditorI18n = {
   ...en_common,
   addParameter: "Add parameter",
   choose: "Choose...",
+  class: "class",
   clear: "Clear",
   columnOperations: {
     delete: "Delete",
@@ -43,6 +44,7 @@ export const en: BoxedExpressionEditorI18n = {
   invocation: "Invocation",
   list: "List",
   literalExpression: "Literal expression",
+  methodSignature: "method signature",
   name: "Name",
   parameters: "PARAMETERS",
   relation: "Relation",


### PR DESCRIPTION
This PR contains implementation of Function Expression for the *JAVA* function kind part.
Currently the nested table (context table) still contains an header, but it is very likely that after KOGITO-4520, which @karreiro is actively working on, the look&feel will be something similar to:
![image](https://user-images.githubusercontent.com/22591802/117713233-ac316200-b1d5-11eb-8c01-abf9d4065f7b.png)
Live version [there](https://vpellegrino.github.io/kie-wb-common/).